### PR TITLE
When available, use skin-pagarme on same branch name for visual diffs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,12 +15,28 @@ jobs:
           - dependencies-{{ checksum "package.json" }}
           - dependencies-
 
-      - run: |
-          yarn
-          yarn lint
-          yarn build
-          yarn test
-          yarn percy; true
+      - run:
+          name: Installing dependencies
+          command: yarn
+
+      - run:
+          name: Linting source files
+          command: yarn lint
+
+      - run:
+          name: Building production bundle
+          command: yarn build
+
+      - run:
+          name: Running tests
+          command: yarn test
+
+      - run:
+          name: Building and uploading storybook for visual diff
+          working_directory: ~/repo
+          command: |
+            scripts/fetch-skin.sh
+            yarn percy; true
 
       - save_cache:
           paths:

--- a/scripts/fetch-skin.sh
+++ b/scripts/fetch-skin.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+pushd /tmp
+
+git clone -b "$CIRCLE_BRANCH" https://github.com/pagarme/former-kit-skin-pagarme skin-pagarme
+
+if test $? -ne 0; then
+  popd
+  exit 0
+fi
+
+pushd skin-pagarme
+
+yarn
+
+yarn build
+
+yarn link
+
+popd
+popd
+
+yarn link former-kit-skin-pagarme


### PR DESCRIPTION
This solves the issue of visual diffs being out of date or requiring
a bump in skin-pagarme because of repository split.

It solves the issue by using the pull-request branch name to fetch
a branch of former-kit-skin-pagarme with the same name and `yarn link`
the packages.