### PR TITLE
chore: fix skin fetch to use master branch

### DIFF
--- a/scripts/fetch-skin.sh
+++ b/scripts/fetch-skin.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
+REPO=https://github.com/pagarme/former-kit-skin-pagarme
+
 pushd /tmp
 
-git clone -b "$CIRCLE_BRANCH" https://github.com/pagarme/former-kit-skin-pagarme skin-pagarme
+git clone --depth=1 -b "$CIRCLE_BRANCH" "$REPO" skin-pagarme
 
 if test $? -ne 0; then
-  popd
-  exit 0
+  rm -rf skin-pagarme
+  git clone --depth=1 "$REPO" skin-pagarme
 fi
 
 pushd skin-pagarme


### PR DESCRIPTION
Currently we have a script which fetches the former-kit-skin-pagarme
repository with the same branch name as the pull request branch for
former-kit.

This allows us to do visual validation on Percy using the same skin
branch as the pull request.

When there's no branch available with the same name, the script just
bails out, effectively making former-kit use the skin version defined
in package.json, which gives us a bad experience for visual validations,
making changes have lots of regressions, until we bump skin on
dependencies.

This commit makes the script fallback to skin's master branch when no
branch with same name is found.