### PR TITLE
chore: remove sidebar-section from styleguide

### DIFF
--- a/config/styleguide.config.js
+++ b/config/styleguide.config.js
@@ -90,7 +90,6 @@ module.exports = {
             '../src/Sidebar/SidebarHeader.js',
             '../src/Sidebar/SidebarLink.js',
             '../src/Sidebar/SidebarLinks.js',
-            '../src/Sidebar/SidebarSections.js',
           ],
         },
         {


### PR DESCRIPTION
Currently the styleguidist config has an reference to `SidebarSection` this cause an error when try to compile, this remove the reference from config.