### PR TITLE
tooltip: refactor component

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -5,43 +5,42 @@ import ThemeConsumer from '../ThemeConsumer'
 
 const ConsumeTheme = ThemeConsumer('UITooltip')
 
-const contentClassNames = (theme, placement) => classNames(theme.tooltip, {
-  [theme.bottomCenter]: placement === 'bottomCenter',
-  [theme.bottomEnd]: placement === 'bottomEnd',
-  [theme.bottomStart]: placement === 'bottomStart',
-  [theme.leftEnd]: placement === 'leftEnd',
-  [theme.leftMiddle]: placement === 'leftMiddle',
-  [theme.leftStart]: placement === 'leftStart',
-  [theme.rightEnd]: placement === 'rightEnd',
-  [theme.rightMiddle]: placement === 'rightMiddle',
-  [theme.rightStart]: placement === 'rightStart',
-  [theme.topCenter]: placement === 'topCenter',
-  [theme.topEnd]: placement === 'topEnd',
-  [theme.topStart]: placement === 'topStart',
-})
-
 class Tooltip extends Component {
   constructor (props) {
     super(props)
 
     this.state = {
-      visible: false,
+      visible: props.visible,
     }
 
     this.handleMouseEnter = this.handleMouseEnter.bind(this)
     this.handleMouseLeave = this.handleMouseLeave.bind(this)
   }
 
-  handleMouseEnter () {
+  componentWillReceiveProps ({ visible }) {
     this.setState({
-      visible: true,
+      visible,
     })
   }
 
+  handleMouseEnter () {
+    if (!this.props.onMouseEnter) {
+      this.setState({
+        visible: true,
+      })
+    }
+
+    this.props.onMouseEnter()
+  }
+
   handleMouseLeave () {
-    this.setState({
-      visible: false,
-    })
+    if (!this.props.onMouseLeave) {
+      this.setState({
+        visible: false,
+      })
+    }
+
+    this.props.onMouseLeave()
   }
 
   render () {
@@ -50,10 +49,9 @@ class Tooltip extends Component {
       content,
       placement,
       theme,
-      visible: visibleProp,
     } = this.props
 
-    const { visible: visibleState } = this.state
+    const { visible } = this.state
 
     return (
       <div
@@ -62,9 +60,10 @@ class Tooltip extends Component {
         onMouseLeave={this.handleMouseLeave}
       >
         { children }
-        {(visibleState || visibleProp) &&
+
+        {visible &&
           <div
-            className={contentClassNames(theme, placement)}
+            className={classNames(theme.tooltip, theme[placement])}
             role="tooltip"
           >
             {content}
@@ -76,6 +75,26 @@ class Tooltip extends Component {
 }
 
 Tooltip.propTypes = {
+  /**
+   * The children can be any kind of component.
+   */
+  children: PropTypes.node.isRequired,
+  /**
+   * The content is used to tooltip and can be any kind of component.
+   */
+  content: PropTypes.node.isRequired,
+  /**
+   * onMouseEnter callback.
+   */
+  onMouseEnter: PropTypes.func,
+  /**
+   * onMouseLeave callback.
+   */
+  onMouseLeave: PropTypes.func,
+  /**
+   * The position you want to render the tooltip when it's visible.
+   */
+  placement: PropTypes.string,
   /**
    * @see [ThemeProvider](#themeprovider) - Theme received from `consumeTheme` wrapper.
    */
@@ -96,24 +115,14 @@ Tooltip.propTypes = {
     topStart: PropTypes.string,
   }),
   /**
-   * The children can be any kind of component.
-   */
-  children: PropTypes.node.isRequired,
-  /**
-   * The content is used to tooltip and can be any kind of component.
-   */
-  content: PropTypes.node.isRequired,
-  /**
-   * The position you want to render the tooltip when it's visible.
-   */
-  placement: PropTypes.string,
-  /**
    * This props mean the tooltip is visible.
    */
   visible: PropTypes.bool,
 }
 
 Tooltip.defaultProps = {
+  onMouseEnter: null,
+  onMouseLeave: null,
   placement: 'leftMiddle',
   theme: {},
   visible: false,

--- a/stories/Tooltip/index.js
+++ b/stories/Tooltip/index.js
@@ -3,6 +3,7 @@ import classNames from 'classnames'
 import { storiesOf } from '@storybook/react'
 
 import Tooltip from '../../src/Tooltip'
+import Spacing from '../../src/Spacing'
 import Section from '../Section'
 
 import {
@@ -16,10 +17,10 @@ import Button from '../../src/Button'
 import style from './style.css'
 
 const lipsum = `
-Lorem ipsum dolor sit amet consectetur adipisicing elit.
-Deleniti officia ipsam consectetur laudantium eius asperiores ut
-maiores corporis, consequuntur natus quae tempora voluptate dolorum
-voluptatibus placeat itaque alias, nam culpa.
+  Lorem ipsum dolor sit amet consectetur adipisicing elit.
+  Deleniti officia ipsam consectetur laudantium eius asperiores ut
+  maiores corporis, consequuntur natus quae tempora voluptate dolorum
+  voluptatibus placeat itaque alias, nam culpa.
 `
 
 const TooltipText = ({ placement, visible }) => (
@@ -31,6 +32,39 @@ const TooltipText = ({ placement, visible }) => (
     <Button>Hover me</Button>
   </Tooltip>
 )
+
+class TooltipState extends React.Component {
+  constructor () {
+    super()
+
+    this.state = {
+      visible: false,
+    }
+  }
+
+  render () {
+    return (
+      <div className={style.flex}>
+        <Tooltip
+          content="Lorem ipsum dolor sit amet consectetur adipisicing elit."
+          onMouseEnter={() => this.setState({ visible: true })}
+          placement="rightMiddle"
+          visible={this.state.visible}
+        >
+          <Button>Hover me</Button>
+        </Tooltip>
+
+        <Spacing />
+
+        <Button
+          onClick={() => this.setState({ visible: true })}
+        >
+          show tooltip
+        </Button>
+      </div>
+    )
+  }
+}
 
 const TooltipVisible = ({ placement }) => (
   <Tooltip
@@ -207,5 +241,10 @@ storiesOf('Tooltip', module)
         <h3>Bottom end</h3>
         <TooltipVisible placement="bottomEnd" />
       </div>
+    </Section>
+  ))
+  .add('control visibility', () => (
+    <Section title="Control visibility">
+      <TooltipState />
     </Section>
   ))

--- a/stories/Tooltip/style.css
+++ b/stories/Tooltip/style.css
@@ -1,3 +1,7 @@
+.flex {
+  display: flex;
+}
+
 .col {
   display: unset;
 }

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -32654,6 +32654,51 @@ exports[`Storyshots Tooltip Visible 1`] = `
 </section>
 `;
 
+exports[`Storyshots Tooltip control visibility 1`] = `
+<section
+  className="typography"
+>
+  <h2>
+    Control visibility
+  </h2>
+  <div>
+    <div
+      className={undefined}
+    >
+      <div
+        className="target"
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        <button
+          className="button flat normalRelevance default"
+          disabled={false}
+          onClick={null}
+          type="button"
+        >
+          <span>
+            Hover me
+          </span>
+        </button>
+      </div>
+      <div
+        className="spacing flex"
+      />
+      <button
+        className="button flat normalRelevance default"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        <span>
+          show tooltip
+        </span>
+      </button>
+    </div>
+  </div>
+</section>
+`;
+
 exports[`Storyshots Typography Font families 1`] = `
 <section
   className="typography"


### PR DESCRIPTION
This PR adds `onHover` prop as a callback function to handle with hover events. With this, we can control the visibility of the `Tooltip` from outside of the component.