### PR TITLE
docs: fix popover render error

### DIFF
--- a/config/styleguide.config.js
+++ b/config/styleguide.config.js
@@ -83,6 +83,7 @@ module.exports = {
           content: '../src/Popover/README.md',
           components: () => [
             '../src/Popover/Popover.js',
+            '../src/Popover/PopoverContent.js',
             '../src/Popover/PopoverMenu.js',
           ],
         },


### PR DESCRIPTION
This PR fix the `Popover` render error in docs:

![screenshot from 2018-07-27 11-04-53](https://user-images.githubusercontent.com/6943919/43325398-f1992af6-918c-11e8-9419-7a84a1960b5d.png)
