### PR TITLE
Tooltip: fix mouse functions missing in props

### DIFF
--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -24,23 +24,31 @@ class Tooltip extends Component {
   }
 
   handleMouseEnter () {
-    if (!this.props.onMouseEnter) {
+    const { onMouseEnter } = this.props
+
+    if (!onMouseEnter) {
       this.setState({
         visible: true,
       })
     }
 
-    this.props.onMouseEnter()
+    if (onMouseEnter) {
+      onMouseEnter()
+    }
   }
 
   handleMouseLeave () {
-    if (!this.props.onMouseLeave) {
+    const { onMouseLeave } = this.props
+
+    if (!onMouseLeave) {
       this.setState({
         visible: false,
       })
     }
 
-    this.props.onMouseLeave()
+    if (onMouseLeave) {
+      onMouseLeave()
+    }
   }
 
   render () {


### PR DESCRIPTION
This PR add a validation before calling `onMouseEnter` and `onMouseLeave` functions.