### PR TITLE
input: fix default prop "value"

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -370,7 +370,7 @@ Input.propTypes = {
   /**
    * Input's value.
    */
-  value: PropTypes.string.isRequired,
+  value: PropTypes.string,
 }
 
 Input.defaultProps = {
@@ -392,6 +392,7 @@ Input.defaultProps = {
   renderer: null,
   theme: {},
   type: 'text',
+  value: '',
 }
 
 export default Input


### PR DESCRIPTION
## Context
Despite that the [attribute `value` at `<input>` element is optional at HTML](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input), on `<Input>` at FormerKit this attribute is required.

This is a not expected behaviour and unnecessary. Because of this, some forms, such as [Pilot Login page](https://github.com/pagarme/pilot/blob/master/packages/pilot/src/containers/Account/Login/index.js#L21-L24), needs to set a blank value to each input. If it not set this empty value, React raises an error:

>Warning: A component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components

## Checklist
- [x] Set a default prop for `value` attribute at `<Input>` element