### PR TITLE
alert: add base dark

### DIFF
--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -2,11 +2,11 @@ import React from 'react'
 import classNames from 'classnames'
 import { isNil } from 'ramda'
 import {
-  oneOf,
   element,
+  func,
+  oneOf,
   shape,
   string,
-  func,
 } from 'prop-types'
 import ThemeConsumer from '../ThemeConsumer'
 import Button from '../Button'
@@ -18,13 +18,14 @@ const consumeTheme = ThemeConsumer('UIAlert')
  */
 const Alert = ({
   action,
+  base,
   children,
   icon,
   onDismiss,
   theme,
   type,
 }) => (
-  <div className={theme.alert}>
+  <div className={classNames(theme.alert, theme[base])}>
     {!isNil(icon) && (
       <div className={classNames(theme.icon, theme[type])}>
         {icon}
@@ -54,6 +55,13 @@ Alert.propTypes = {
    */
   action: string,
   /**
+   * The action text.
+   */
+  base: oneOf([
+    'dark',
+    'light',
+  ]),
+  /**
    * The children element. It should contain a React element.
    */
   children: element.isRequired,
@@ -70,12 +78,12 @@ Alert.propTypes = {
    */
   theme: shape({
     alert: string,
-    icon: string,
     content: string,
-    warning: string,
-    info: string,
     error: string,
+    icon: string,
+    info: string,
     success: string,
+    warning: string,
   }),
   /**
    * The types the alert can have. The background color
@@ -91,6 +99,7 @@ Alert.propTypes = {
 
 Alert.defaultProps = {
   action: null,
+  base: 'light',
   icon: null,
   onDismiss: null,
   theme: {},

--- a/stories/Alert/index.js
+++ b/stories/Alert/index.js
@@ -1,21 +1,22 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
+import { storiesOf } from '@storybook/react'
+
 import IconCheck from 'emblematic-icons/svg/Check32.svg'
+import IconClear from 'emblematic-icons/svg/ClearClose32.svg'
 import IconInfo from 'emblematic-icons/svg/Info32.svg'
 import IconWarning from 'emblematic-icons/svg/Warning32.svg'
-import IconClear from 'emblematic-icons/svg/ClearClose32.svg'
-import Section from '../Section'
-import Alert from '../../src/Alert'
 
+import Alert from '../../src/Alert'
+import Section from '../Section'
 
 storiesOf('Alerts', module)
   .add('Default', () => (
     <div>
       <Section title="Warning">
         <Alert
-          type="warning"
           icon={<IconWarning height={16} width={16} />}
+          type="warning"
         >
           <p><strong>Warning.</strong> Something is going on!</p>
         </Alert>
@@ -23,8 +24,8 @@ storiesOf('Alerts', module)
 
       <Section title="Info">
         <Alert
-          type="info"
           icon={<IconInfo height={16} width={16} />}
+          type="info"
         >
           <p><strong>Info.</strong> You can do it better!</p>
         </Alert>
@@ -32,8 +33,8 @@ storiesOf('Alerts', module)
 
       <Section title="Error">
         <Alert
-          type="error"
           icon={<IconClear height={16} width={16} />}
+          type="error"
         >
           <p><strong>Error.</strong> Something went wrong!</p>
         </Alert>
@@ -41,8 +42,8 @@ storiesOf('Alerts', module)
 
       <Section title="Success">
         <Alert
-          type="success"
           icon={<IconCheck height={16} width={16} />}
+          type="success"
         >
           <p><strong>Success.</strong> Awesome, it worked!</p>
         </Alert>
@@ -50,14 +51,65 @@ storiesOf('Alerts', module)
 
       <Section title="Event">
         <Alert
-          type="warning"
-          icon={<IconWarning height={16} width={16} />}
           action="dismiss"
+          icon={<IconWarning height={16} width={16} />}
           onDismiss={action('dismiss')}
+          type="warning"
+        >
+          <p><strong>Warning.</strong> Something is going on!</p>
+        </Alert>
+      </Section>
+
+      <Section title="Warning" base="dark">
+        <Alert
+          base="dark"
+          icon={<IconWarning height={16} width={16} />}
+          type="warning"
+        >
+          <p><strong>Warning.</strong> Something is going on!</p>
+        </Alert>
+      </Section>
+
+      <Section title="Info" base="dark">
+        <Alert
+          base="dark"
+          icon={<IconInfo height={16} width={16} />}
+          type="info"
+        >
+          <p><strong>Info.</strong> You can do it better!</p>
+        </Alert>
+      </Section>
+
+      <Section title="Error" base="dark">
+        <Alert
+          base="dark"
+          icon={<IconClear height={16} width={16} />}
+          type="error"
+        >
+          <p><strong>Error.</strong> Something went wrong!</p>
+        </Alert>
+      </Section>
+
+      <Section title="Success" base="dark">
+        <Alert
+          base="dark"
+          icon={<IconCheck height={16} width={16} />}
+          type="success"
+        >
+          <p><strong>Success.</strong> Awesome, it worked!</p>
+        </Alert>
+      </Section>
+
+      <Section title="Event" base="dark">
+        <Alert
+          action="dismiss"
+          base="dark"
+          icon={<IconWarning height={16} width={16} />}
+          onDismiss={action('dismiss')}
+          type="warning"
         >
           <p><strong>Warning.</strong> Something is going on!</p>
         </Alert>
       </Section>
     </div>
   ))
-

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -12,7 +12,7 @@ exports[`Storyshots Alerts Default 1`] = `
     </h2>
     <div>
       <div
-        className="alert"
+        className="alert light"
       >
         <div
           className="icon warning"
@@ -45,7 +45,7 @@ exports[`Storyshots Alerts Default 1`] = `
     </h2>
     <div>
       <div
-        className="alert"
+        className="alert light"
       >
         <div
           className="icon info"
@@ -78,7 +78,7 @@ exports[`Storyshots Alerts Default 1`] = `
     </h2>
     <div>
       <div
-        className="alert"
+        className="alert light"
       >
         <div
           className="icon error"
@@ -111,7 +111,7 @@ exports[`Storyshots Alerts Default 1`] = `
     </h2>
     <div>
       <div
-        className="alert"
+        className="alert light"
       >
         <div
           className="icon success"
@@ -144,7 +144,182 @@ exports[`Storyshots Alerts Default 1`] = `
     </h2>
     <div>
       <div
-        className="alert"
+        className="alert light"
+      >
+        <div
+          className="icon warning"
+        >
+          <Warning32.svg
+            height={16}
+            width={16}
+          />
+        </div>
+        <div
+          aria-live="polite"
+          className="content"
+          role="status"
+        >
+          <p>
+            <strong>
+              Warning.
+            </strong>
+             Something is going on!
+          </p>
+          <button
+            className="button clean normalRelevance default"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              dismiss
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className=""
+  >
+    <h2>
+      Warning
+    </h2>
+    <div>
+      <div
+        className="alert dark"
+      >
+        <div
+          className="icon warning"
+        >
+          <Warning32.svg
+            height={16}
+            width={16}
+          />
+        </div>
+        <div
+          aria-live="polite"
+          className="content"
+          role="status"
+        >
+          <p>
+            <strong>
+              Warning.
+            </strong>
+             Something is going on!
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className=""
+  >
+    <h2>
+      Info
+    </h2>
+    <div>
+      <div
+        className="alert dark"
+      >
+        <div
+          className="icon info"
+        >
+          <Info32.svg
+            height={16}
+            width={16}
+          />
+        </div>
+        <div
+          aria-live="polite"
+          className="content"
+          role="status"
+        >
+          <p>
+            <strong>
+              Info.
+            </strong>
+             You can do it better!
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className=""
+  >
+    <h2>
+      Error
+    </h2>
+    <div>
+      <div
+        className="alert dark"
+      >
+        <div
+          className="icon error"
+        >
+          <ClearClose32.svg
+            height={16}
+            width={16}
+          />
+        </div>
+        <div
+          aria-live="polite"
+          className="content"
+          role="status"
+        >
+          <p>
+            <strong>
+              Error.
+            </strong>
+             Something went wrong!
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className=""
+  >
+    <h2>
+      Success
+    </h2>
+    <div>
+      <div
+        className="alert dark"
+      >
+        <div
+          className="icon success"
+        >
+          <Check32.svg
+            height={16}
+            width={16}
+          />
+        </div>
+        <div
+          aria-live="polite"
+          className="content"
+          role="status"
+        >
+          <p>
+            <strong>
+              Success.
+            </strong>
+             Awesome, it worked!
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className=""
+  >
+    <h2>
+      Event
+    </h2>
+    <div>
+      <div
+        className="alert dark"
       >
         <div
           className="icon warning"


### PR DESCRIPTION
## Context
Refactor `Alert` component to use the Dark base.

## Checklist
- [x] Add Base Dark class to `former-kit-skin`
- [x] Add Base Dark props to Alert component
- [x] Add Dark and Light bases in Former-kit Storybook

## Linked Issues
- [x] Resolves #189 

### Layout:
`Zeplin`: http://zpl.io/aRMjP80

### Preview:
![image](https://user-images.githubusercontent.com/20358128/45390271-0331a400-b5f5-11e8-80a8-dac374373884.png)


