### PR TITLE
section: add dark base

### DIFF
--- a/stories/Section.js
+++ b/stories/Section.js
@@ -5,11 +5,17 @@ import classnames from 'classnames'
 import styles from './style.css'
 
 const Section = ({
+  base,
   title,
   children,
   className,
 }) => (
-  <section className={classnames(styles.section, className)}>
+  <section className={
+    classnames(
+      styles[base],
+      styles.section,
+      className)}
+  >
     {title &&
       <h2>{title}</h2>
     }
@@ -18,11 +24,16 @@ const Section = ({
 )
 
 Section.propTypes = {
+  base: PropTypes.oneOf([
+    'light',
+    'dark',
+  ]),
   title: PropTypes.string,
   children: PropTypes.node.isRequired,
 }
 
 Section.defaultProps = {
+  base: 'light',
   title: '',
 }
 

--- a/stories/style.css
+++ b/stories/style.css
@@ -1,7 +1,26 @@
+@import "former-kit-skin-pagarme/dist/styles/colors/light.css";
+@import "former-kit-skin-pagarme/dist/styles/spacing.css";
+
 .section {
-  padding: 15px;
+  padding: var(--spacing-small);
+
+  & > h2 {
+    margin: 0 0 var(--spacing-small);
+  }
 }
 
-.section > h2 {
-  margin: 0 0 15px;
+.dark {
+  background-color: var(--color-light-carbon-50);
+
+  & h2 {
+    color: var(--color-white);
+  }
+}
+
+.light {
+  background-color: var(--color-white);
+
+  & h2 {
+    color: var(--color-light-coal-100);
+  }
 }


### PR DESCRIPTION
## Context
I've added a Dark base to the `Section` component of the Storybook to make it easier to see the components that will be with the Dark base.

I also added the variables of the Former-Kit-Skin and put 16px instead of 15px on the margins and paddings of the `style.css` file.

## Checklist
- [x] Dark base to `Section` component
- [x] Add former-kit-skin-pagarme variables
