### PR TITLE
alert: fix base theme strings

### DIFF
--- a/src/Alert/index.js
+++ b/src/Alert/index.js
@@ -79,9 +79,11 @@ Alert.propTypes = {
   theme: shape({
     alert: string,
     content: string,
+    dark: string,
     error: string,
     icon: string,
     info: string,
+    light: string,
     success: string,
     warning: string,
   }),


### PR DESCRIPTION
## Context
There were missing strings in the `Alert` theme provider.

## Checklist
- [X] Add `dark` and `light` strings to the theme provider.

### Layout:
https://zpl.io/aRMjP80