### PR TITLE
Modal: add "closeTimeoutMS" prop

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -13,7 +13,6 @@ const consumeTheme = ThemeConsumer('UIModal')
  */
 const Modal = ({
   children,
-  closeTimeoutMS,
   isOpen,
   onRequestClose,
   theme,
@@ -25,7 +24,7 @@ const Modal = ({
       afterOpen: theme.modalAfterOpen,
       beforeClose: theme.modalBeforeClose,
     }}
-    closeTimeoutMS={closeTimeoutMS}
+    closeTimeoutMS={200}
     isOpen={isOpen}
     onRequestClose={onRequestClose}
     overlayClassName={{
@@ -53,10 +52,6 @@ Modal.propTypes = {
    * Set of React elements which will be rendered inside the modal.
    */
   children: PropTypes.node.isRequired,
-  /**
-   * Set a close timeout in milliseconds for children components.
-   */
-  closeTimeoutMS: PropTypes.number.isRequired,
   /**
    * Indicates if the modal is being shown.
    */

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -13,16 +13,26 @@ const consumeTheme = ThemeConsumer('UIModal')
  */
 const Modal = ({
   children,
+  closeTimeoutMS,
   isOpen,
   onRequestClose,
   theme,
 }) => (
   <ReactModal
     appElement={document.body}
-    className={theme.modal}
+    className={{
+      base: theme.modal,
+      afterOpen: theme.modalAfterOpen,
+      beforeClose: theme.modalBeforeClose,
+    }}
+    closeTimeoutMS={closeTimeoutMS}
     isOpen={isOpen}
     onRequestClose={onRequestClose}
-    overlayClassName={theme.overlay}
+    overlayClassName={{
+      base: theme.overlay,
+      afterOpen: theme.overlayAfterOpen,
+      beforeClose: theme.overlayBeforeClose,
+    }}
     parentSelector={() => document.body}
     role="dialog"
   >
@@ -43,6 +53,10 @@ Modal.propTypes = {
    * Set of React elements which will be rendered inside the modal.
    */
   children: PropTypes.node.isRequired,
+  /**
+   * Set a close timeout in milliseconds for children components.
+   */
+  closeTimeoutMS: PropTypes.number.isRequired,
   /**
    * Indicates if the modal is being shown.
    */

--- a/stories/Modal/index.js
+++ b/stories/Modal/index.js
@@ -50,7 +50,6 @@ class ModalWithState extends Component {
 
         {/* modal content definition */}
         <Modal
-          closeTimeoutMS={200}
           label="Create a Transaction"
           isOpen={this.state.isOpen}
           onRequestClose={this.handleToggleModal}

--- a/stories/Modal/index.js
+++ b/stories/Modal/index.js
@@ -50,6 +50,7 @@ class ModalWithState extends Component {
 
         {/* modal content definition */}
         <Modal
+          closeTimeoutMS={200}
           label="Create a Transaction"
           isOpen={this.state.isOpen}
           onRequestClose={this.handleToggleModal}


### PR DESCRIPTION
## Context
In order for the before-close property to be viewed, I had to modify the component to receive a property called "closeTimeoutMS". To know more about this rule, [click here](http://reactcommunity.org/react-modal/styles/classes.html).

This PR is related to https://github.com/pagarme/former-kit-skin-pagarme/pull/148 and https://github.com/pagarme/pilot/pull/1014.

## Checklist
- [x] Add `closeTimeoutMS` prop in `<ReactModal />` component

## Linked Issues
- [x] Resolves https://github.com/pagarme/pilot/issues/858

## How to test
- Go to `add/modal-transition` branch in all repositories
```
git checkout add/modal-transition
```
- Create a link to former-kit-skin e former-kit repositories
```
yarn link
```

- Link former-kit-skin-pagarme
```
yarn link former-kit
```

- Link former-kit-skin-pagarme inside Pilot
```
yarn link former-kit
yarn link former-kit-skin
```

- Run normally storybook at former-kit/Pilot
```
yarn storybook
```

