### PR TITLE
popover: add prop to handle with click outside

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -12,7 +12,7 @@ class Popover extends Component {
     super(props)
 
     this.state = {
-      visible: this.props.visible,
+      visible: props.visible,
     }
 
     this.handleOnClick = this.handleOnClick.bind(this)
@@ -26,9 +26,13 @@ class Popover extends Component {
   }
 
   handleClickOutside () {
-    this.setState({
-      visible: false,
-    })
+    const { closeWhenClickOutside } = this.props
+
+    if (closeWhenClickOutside) {
+      this.setState({
+        visible: false,
+      })
+    }
   }
 
   handleOnClick () {
@@ -92,6 +96,10 @@ Popover.propTypes = {
    */
   children: PropTypes.node.isRequired,
   /**
+   * The element should close when click outside popover.
+   */
+  closeWhenClickOutside: PropTypes.bool,
+  /**
    * The popover content.
    */
   content: PropTypes.node.isRequired,
@@ -111,6 +119,7 @@ Popover.propTypes = {
 
 Popover.defaultProps = {
   base: null,
+  closeWhenClickOutside: true,
   onClick: null,
   placement: 'bottomStart',
   theme: {},

--- a/stories/Popover/index.js
+++ b/stories/Popover/index.js
@@ -200,3 +200,16 @@ storiesOf('Popover', module)
       <PopoverControl />
     </Section>
   ))
+  .add('Don\'t close popover when click outside', () => (
+    <Section>
+      <Popover
+        closeWhenClickOutside={false}
+        content={<Menu />}
+        placement="rightStart"
+      >
+        <Button>
+          Open Popover
+        </Button>
+      </Popover>
+    </Section>
+  ))

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -29036,6 +29036,43 @@ exports[`Storyshots Popover Default 1`] = `
 </section>
 `;
 
+exports[`Storyshots Popover Don't close popover when click outside 1`] = `
+<section
+  className="typography"
+>
+  
+  <div>
+    <div
+      className="target"
+      onClick={[Function]}
+      role="presentation"
+    >
+      <button
+        className="button flat normalRelevance default"
+        disabled={false}
+        onClick={[Function]}
+        type="button"
+      >
+        <span>
+          Open Popover
+        </span>
+        <span
+          className="ripple"
+          style={
+            Object {
+              "height": 0,
+              "left": 0,
+              "top": 0,
+              "width": 0,
+            }
+          }
+        />
+      </button>
+    </div>
+  </div>
+</section>
+`;
+
 exports[`Storyshots Popover Handle close popover 1`] = `
 <section
   className="typography"


### PR DESCRIPTION
## Context
This PR add the `closeWhenClickOutside` to component to handle with cases when it is not allowed close the popover.
