### PR TITLE
inputs: update mask input

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-addons-shallow-compare": "15.6.2",
     "react-click-outside": "3.0.0",
     "react-dates": "12.7.1",
+    "react-input-mask": "2.0.4",
     "react-maskedinput": "4.0.1",
     "react-modal": "3.1.11",
     "react-motion": "0.5.2",

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import shortid from 'shortid'
-import MaskedInput from 'react-maskedinput'
+import MaskedInput from 'react-input-mask'
 import {
   dissoc,
   isEmpty,
@@ -128,6 +128,9 @@ class Input extends React.PureComponent {
     if (mask) {
       return (
         <MaskedInput
+          formatChars={{
+            1: '[0-9]',
+          }}
           mask={mask}
           onChange={disabled ? null : onChange}
           onBlur={this.handleBlur}

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -23099,14 +23099,12 @@ exports[`Storyshots Inputs Default 1`] = `
           >
             <input
               disabled={false}
-              mask="111-111-111"
-              maxLength={11}
               name="email"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
+              onKeyPress={null}
+              onMouseDown={[Function]}
               onPaste={[Function]}
               placeholder="Type your phone number"
               size={null}
@@ -23993,14 +23991,12 @@ exports[`Storyshots Inputs Default 1`] = `
           >
             <input
               disabled={false}
-              mask="111-111-111"
-              maxLength={11}
               name="email"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
+              onKeyPress={null}
+              onMouseDown={[Function]}
               onPaste={[Function]}
               placeholder="Type your phone number"
               size={null}
@@ -24849,14 +24845,12 @@ exports[`Storyshots Inputs Form 1`] = `
           >
             <input
               disabled={false}
-              mask="111-111-111"
-              maxLength={11}
               name="email"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
+              onKeyPress={null}
+              onMouseDown={[Function]}
               onPaste={[Function]}
               placeholder="Type your phone number"
               size={null}
@@ -25743,14 +25737,12 @@ exports[`Storyshots Inputs Form 1`] = `
           >
             <input
               disabled={false}
-              mask="111-111-111"
-              maxLength={11}
               name="email"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              onKeyPress={[Function]}
+              onKeyPress={null}
+              onMouseDown={[Function]}
               onPaste={[Function]}
               placeholder="Type your phone number"
               size={null}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5877,7 +5877,7 @@ intl@1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
 
-invariant@^2.2.0, invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   dependencies:
@@ -9619,6 +9619,14 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
+react-input-mask@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-input-mask/-/react-input-mask-2.0.4.tgz#9ade5cf8196f4a856dbf010820fe75a795f3eb14"
+  integrity sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==
+  dependencies:
+    invariant "^2.2.4"
+    warning "^4.0.2"
+
 react-inspector@^2.2.2:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.3.0.tgz#fc9c1d38ab687fc0d190dcaf133ae40158968fc8"
@@ -11885,6 +11893,13 @@ walker@~1.0.5:
 warning@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/warning/-/warning-3.0.0.tgz#32e5377cb572de4ab04753bdf8821c01ed605b7c"
+  dependencies:
+    loose-envify "^1.0.0"
+
+warning@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.2.tgz#aa6876480872116fa3e11d434b0d0d8d91e44607"
+  integrity sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==
   dependencies:
     loose-envify "^1.0.0"
 


### PR DESCRIPTION
## Context
Currently the [React MaskedInput](https://github.com/insin/react-maskedinput) library used to create masks in form fields has a conflict with the `react-vanilla-form` library which does not trigger the functions of `onChange` that is applied in the input, being necessary to create a specific function for this which is quite complex and not ideal. After testing with another library, I realized that the same problem does not occur.

## Checklist
- [x] Perform the `onChange` that is applied to the input by vanilla-form avoiding the need to create an` onChangeWithMask` function.

**New dependencies**:
- [React Input Mask](https://github.com/insin/react-maskedinput)

## How to test:
1. checkout for this branch: `git checkout update / masked-input`.
2. install the new dependencies: `yarn`.
3. run the storybook: `yarn storybook`.

**To better test with a real case, follow these steps:**
1. take the first two steps above.
2. link the former-kit to Pilot.
3. in some input that has the `onChangeWithMask` function or something similar removes the function, leaving only the` onChange` applied to `Form` (react-vanilla-form).
4. run the storybook and verify that the container state updates correctly.

Resolve #218 