### PR TITLE
dropdown: fix prop value

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -117,7 +117,7 @@ class Dropdown extends React.Component {
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
           disabled={disabled}
-          defaultValue={value || 'placeholder'}
+          value={value || 'placeholder'}
         >
           <option
             disabled

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -17491,12 +17491,12 @@ exports[`Storyshots Dropdown Default 1`] = `
           
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={false}
             id="things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -17553,12 +17553,12 @@ exports[`Storyshots Dropdown Default 1`] = `
           
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={false}
             id="things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -17615,12 +17615,12 @@ exports[`Storyshots Dropdown Default 1`] = `
           
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={false}
             id="things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -17677,12 +17677,12 @@ exports[`Storyshots Dropdown Default 1`] = `
           
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={false}
             id="things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -17743,12 +17743,12 @@ exports[`Storyshots Dropdown Default 1`] = `
           
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={true}
             id="things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -17805,12 +17805,12 @@ exports[`Storyshots Dropdown Default 1`] = `
           
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={true}
             id="things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -17867,12 +17867,12 @@ exports[`Storyshots Dropdown Default 1`] = `
           
           <select
             className="select"
-            defaultValue="open-source"
             disabled={false}
             id="things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="open-source"
           >
             <option
               className="option placeholder"
@@ -17941,12 +17941,12 @@ exports[`Storyshots Dropdown Form 1`] = `
           </label>
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={false}
             id="Things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -18008,12 +18008,12 @@ exports[`Storyshots Dropdown Form 1`] = `
           </label>
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={false}
             id="Things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -18075,12 +18075,12 @@ exports[`Storyshots Dropdown Form 1`] = `
           </label>
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={false}
             id="Things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -18146,12 +18146,12 @@ exports[`Storyshots Dropdown Form 1`] = `
           </label>
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={true}
             id="Things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -18213,12 +18213,12 @@ exports[`Storyshots Dropdown Form 1`] = `
           </label>
           <select
             className="select"
-            defaultValue="placeholder"
             disabled={true}
             id="Things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="placeholder"
           >
             <option
               className="option placeholder"
@@ -18280,12 +18280,12 @@ exports[`Storyshots Dropdown Form 1`] = `
           </label>
           <select
             className="select"
-            defaultValue="open-source"
             disabled={false}
             id="Things-shortid-mock"
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
+            value="open-source"
           >
             <option
               className="option placeholder"


### PR DESCRIPTION
## Context

O component de `select` recebia uma prop chamada `defaultValue` que era encarregada de passar o valor padrão para o component e apresentar se houvesse esse valor, porém não existia essa prop dado isso, mudamos para `value` como é dito na documentação do react (https://reactjs.org/docs/forms.html#the-select-tag) fazendo isso, se o `value` refletir algum dos valores de `options` já virá com esse valor selecionado e adicionando a tag `selected` a aquela option.

 
## Linked Issues
- [x] https://github.com/pagarme/former-kit/issues/223