### PR TITLE
sidebar: add expanded className and removes SidebarContent component

### DIFF
--- a/src/Layout/examples/SidebarState.js
+++ b/src/Layout/examples/SidebarState.js
@@ -8,13 +8,9 @@ import shortid from 'shortid'
 import {
   Sidebar,
   SidebarHeader,
-  SidebarContent,
   SidebarLinks,
   SidebarLink,
 } from '../../Sidebar'
-
-import Tag from '../../Tag'
-import SegmentedSwitch from '../../SegmentedSwitch'
 
 const items = [
   {
@@ -37,23 +33,13 @@ class SidebarState extends React.Component {
 
     this.state = {
       collapsed: false,
-      selectedEnvironment: 'live',
       active: '',
     }
-
-    this.handleEnvironment = this.handleEnvironment.bind(this)
-  }
-
-  handleEnvironment (env) {
-    this.setState({
-      selectedEnvironment: env,
-    })
   }
 
   render () {
     const {
       collapsed,
-      selectedEnvironment,
     } = this.state
 
     return (
@@ -70,27 +56,6 @@ class SidebarState extends React.Component {
             <IconMenu width="16" height="16" />
           </button>
         </SidebarHeader>
-
-        <SidebarContent>
-          {collapsed
-            ? <Tag key={selectedEnvironment}>{selectedEnvironment}</Tag>
-            : <SegmentedSwitch
-              options={[
-                {
-                  title: 'Test',
-                  value: 'test',
-                },
-                {
-                  title: 'Live',
-                  value: 'live',
-                },
-              ]}
-              value={this.state.selectedEnvironment}
-              name={`${this.id}-live-test`}
-              onChange={this.handleEnvironment}
-            />
-          }
-        </SidebarContent>
 
         <SidebarLinks>
           {items.map(item => (

--- a/src/Sidebar/README.md
+++ b/src/Sidebar/README.md
@@ -58,13 +58,6 @@ class SidebarState extends React.Component {
     }
 
     this.handleClick = this.handleClick.bind(this)
-    this.handleEnvironment = this.handleEnvironment.bind(this)
-  }
-
-  handleEnvironment (env) {
-    this.setState({
-      selectedEnvironment: env,
-    })
   }
 
   handleClick (link) {
@@ -118,27 +111,6 @@ class SidebarState extends React.Component {
             </SidebarLink>
           ))}
         </SidebarLinks>
-
-        <SidebarContent>
-          {collapsed
-            ? <Tag key={selectedEnvironment}>{selectedEnvironment}</Tag>
-            : <SegmentedSwitch
-              options={[
-                {
-                  title: 'Test',
-                  value: 'test',
-                },
-                {
-                  title: 'Live',
-                  value: 'live',
-                },
-              ]}
-              value={this.state.selectedEnvironment}
-              name={`${this.id}-live-test`}
-              onChange={this.handleEnvironment}
-            />
-          }
-        </SidebarContent>
       </Sidebar>
     )
   }

--- a/src/Sidebar/Sidebar.js
+++ b/src/Sidebar/Sidebar.js
@@ -14,6 +14,7 @@ const Sidebar = ({
   <aside
     className={classNames(theme.sidebar, {
       [theme.collapsed]: collapsed,
+      [theme.expanded]: !collapsed,
     })}
   >
     {children}

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -1,5 +1,4 @@
 export { default as Sidebar } from './Sidebar'
 export { default as SidebarHeader } from './SidebarHeader'
-export { default as SidebarContent } from './SidebarContent'
 export { default as SidebarLinks } from './SidebarLinks'
 export { default as SidebarLink } from './SidebarLink'

--- a/stories/Sidebar/SidebarState.js
+++ b/stories/Sidebar/SidebarState.js
@@ -10,14 +10,11 @@ import { contains } from 'ramda'
 import {
   Sidebar,
   SidebarHeader,
-  SidebarContent,
   SidebarLinks,
   SidebarLink,
 } from '../../src/Sidebar'
 
 import Button from '../../src/Button'
-import Tag from '../../src/Tag'
-import SegmentedSwitch from '../../src/SegmentedSwitch'
 
 import Logo from './logo.svg'
 
@@ -62,18 +59,10 @@ class SidebarState extends React.Component {
 
     this.state = {
       collapsed: props.collapsed || false,
-      selectedEnvironment: 'live',
       active: [],
     }
 
     this.handleClick = this.handleClick.bind(this)
-    this.handleEnvironment = this.handleEnvironment.bind(this)
-  }
-
-  handleEnvironment (env) {
-    this.setState({
-      selectedEnvironment: env,
-    })
   }
 
   handleClick (link) {
@@ -85,7 +74,6 @@ class SidebarState extends React.Component {
   render () {
     const {
       collapsed,
-      selectedEnvironment,
     } = this.state
 
     return (
@@ -127,27 +115,6 @@ class SidebarState extends React.Component {
             </SidebarLink>
           ))}
         </SidebarLinks>
-
-        <SidebarContent>
-          {collapsed
-            ? <Tag key={selectedEnvironment}>{selectedEnvironment}</Tag>
-            : <SegmentedSwitch
-              name={`${this.id}-live-test`}
-              onChange={this.handleEnvironment}
-              options={[
-                {
-                  title: 'Live',
-                  value: 'live',
-                },
-                {
-                  title: 'Test',
-                  value: 'test',
-                },
-              ]}
-              value={this.state.selectedEnvironment}
-            />
-          }
-        </SidebarContent>
       </Sidebar>
     )
   }

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -26708,7 +26708,7 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
     className="layout"
   >
     <aside
-      className="sidebar"
+      className="sidebar expanded"
     >
       <header
         className="header"
@@ -26822,52 +26822,6 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
           </li>
         </ul>
       </nav>
-      <div
-        className="content"
-      >
-        <div
-          className="segmentedSwitch"
-        >
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-          >
-            <input
-              checked={true}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="live"
-            />
-            <span
-              className="label"
-            >
-              Live
-            </span>
-          </label>
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-          >
-            <input
-              checked={false}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="test"
-            />
-            <span
-              className="label"
-            >
-              Test
-            </span>
-          </label>
-        </div>
-      </div>
     </aside>
     <div
       className="wrapper"
@@ -27199,7 +27153,7 @@ exports[`Storyshots Layout Default with all props 1`] = `
     className="layout"
   >
     <aside
-      className="sidebar"
+      className="sidebar expanded"
     >
       <header
         className="header"
@@ -27313,52 +27267,6 @@ exports[`Storyshots Layout Default with all props 1`] = `
           </li>
         </ul>
       </nav>
-      <div
-        className="content"
-      >
-        <div
-          className="segmentedSwitch"
-        >
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-          >
-            <input
-              checked={true}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="live"
-            />
-            <span
-              className="label"
-            >
-              Live
-            </span>
-          </label>
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-          >
-            <input
-              checked={false}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="test"
-            />
-            <span
-              className="label"
-            >
-              Test
-            </span>
-          </label>
-        </div>
-      </div>
     </aside>
     <div
       className="wrapper"
@@ -27794,7 +27702,7 @@ exports[`Storyshots Layout Default without Footer 1`] = `
     className="layout"
   >
     <aside
-      className="sidebar"
+      className="sidebar expanded"
     >
       <header
         className="header"
@@ -27908,52 +27816,6 @@ exports[`Storyshots Layout Default without Footer 1`] = `
           </li>
         </ul>
       </nav>
-      <div
-        className="content"
-      >
-        <div
-          className="segmentedSwitch"
-        >
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-          >
-            <input
-              checked={true}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="live"
-            />
-            <span
-              className="label"
-            >
-              Live
-            </span>
-          </label>
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-          >
-            <input
-              checked={false}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="test"
-            />
-            <span
-              className="label"
-            >
-              Test
-            </span>
-          </label>
-        </div>
-      </div>
     </aside>
     <div
       className="wrapper"
@@ -28334,7 +28196,7 @@ exports[`Storyshots Layout Default without Header 1`] = `
     className="layout"
   >
     <aside
-      className="sidebar"
+      className="sidebar expanded"
     >
       <header
         className="header"
@@ -28448,52 +28310,6 @@ exports[`Storyshots Layout Default without Header 1`] = `
           </li>
         </ul>
       </nav>
-      <div
-        className="content"
-      >
-        <div
-          className="segmentedSwitch"
-        >
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-          >
-            <input
-              checked={true}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="live"
-            />
-            <span
-              className="label"
-            >
-              Live
-            </span>
-          </label>
-          <label
-            className="item"
-            htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-          >
-            <input
-              checked={false}
-              disabled={false}
-              id="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-              name="segmented-switch-shortid-mock"
-              onChange={[Function]}
-              type="radio"
-              value="test"
-            />
-            <span
-              className="label"
-            >
-              Test
-            </span>
-          </label>
-        </div>
-      </div>
     </aside>
     <div
       className="wrapper"
@@ -33862,21 +33678,12 @@ exports[`Storyshots Sidebar Collapsed 1`] = `
       </li>
     </ul>
   </nav>
-  <div
-    className="content"
-  >
-    <div
-      className="tag"
-    >
-      live
-    </div>
-  </div>
 </aside>
 `;
 
 exports[`Storyshots Sidebar Default 1`] = `
 <aside
-  className="sidebar"
+  className="sidebar expanded"
 >
   <header
     className="header"
@@ -33990,52 +33797,6 @@ exports[`Storyshots Sidebar Default 1`] = `
       </li>
     </ul>
   </nav>
-  <div
-    className="content"
-  >
-    <div
-      className="segmentedSwitch"
-    >
-      <label
-        className="item"
-        htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-      >
-        <input
-          checked={true}
-          disabled={false}
-          id="segmented-switch-shortid-mock-shortid-mock-live-test-live"
-          name="segmented-switch-shortid-mock"
-          onChange={[Function]}
-          type="radio"
-          value="live"
-        />
-        <span
-          className="label"
-        >
-          Live
-        </span>
-      </label>
-      <label
-        className="item"
-        htmlFor="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-      >
-        <input
-          checked={false}
-          disabled={false}
-          id="segmented-switch-shortid-mock-shortid-mock-live-test-test"
-          name="segmented-switch-shortid-mock"
-          onChange={[Function]}
-          type="radio"
-          value="test"
-        />
-        <span
-          className="label"
-        >
-          Test
-        </span>
-      </label>
-    </div>
-  </div>
 </aside>
 `;
 


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->

## Context
This is part of Sidebar's MicroInteration https://github.com/pagarme/pilot/issues/854 .

## Checklist
- [x] Add `expanded` className
- [x] Removes `<SidebarContent>` (Live and Test button)

## Linked Issues
- [x] Resolves https://github.com/pagarme/pilot/issues/854

### Preview:
![feb-12-2019 16-05-27](https://user-images.githubusercontent.com/20358128/52657552-10262c80-2ee0-11e9-9021-25589ae2034b.gif)
