### PR TITLE
Refactor Tag component props

### DIFF
--- a/src/Tag/index.js
+++ b/src/Tag/index.js
@@ -29,9 +29,9 @@ Tag.propTypes = {
     tag: PropTypes.string,
   }),
   /*
-   * The 'children' prop is a string.
+   * The 'children' prop is a node, it could be a string or a react element
    */
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
 }
 
 Tag.defaultProps = {


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->
This PR changes the `children` prop validation to accept other types besides strings. Now we can pass a `node`(string, array, element or function) as children.

## Context
<!-- What problem are you trying to solve? -->
This will solve the Tag warnings when elements are received as children.

## Screenshots
The following picture shows the error, it occurs in this case because we mix React elements and text inside the `Tag` component.
<img width="1613" alt="screen shot 2019-02-20 at 18 31 44" src="https://user-images.githubusercontent.com/1773766/53125952-ddaeac00-353d-11e9-9763-8715b2ca5ef6.png">

