### PR TITLE
DateInput - Adiciona no input a data do preset pré-selecionado

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "postcss-url": "8.0.0",
     "react-dev-utils": "7.0.1",
     "react-error-overlay": "5.1.2",
-    "react-moment-proptypes": "1.5.0",
     "react-styleguidist": "8.0.6",
     "react-test-renderer": "16.7.0",
     "react-testing-library": "5.4.4",

--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -19,6 +19,7 @@ import ThemeConsumer from '../ThemeConsumer'
 import {
   validateDate,
 } from '../DateInput/dateHelpers'
+import isMomentPropValidation from '../validations'
 
 const consumeTheme = ThemeConsumer('UICalendar')
 
@@ -51,16 +52,6 @@ const isOutsideRange = limits => complement(validateDate(limits))
 
 const validateVisibleMonths = (currentMonth, months) =>
   times(add(currentMonth), months)
-
-export const isMomentPropValidation = (props, propName) => {
-  const propValue = props[propName]
-
-  if (propValue && !moment.isMoment(propValue)) {
-    return new Error(`Prop ${propName} must be an instance of Moment`)
-  }
-
-  return null
-}
 
 /**
  * Custom calendar based on `react-dates` from airbnb with a simple interface.

--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -13,6 +13,7 @@ import {
   omit,
   times,
 } from 'ramda'
+
 import normalizeDates from './normalizeDates'
 import ThemeConsumer from '../ThemeConsumer'
 import {
@@ -50,6 +51,16 @@ const isOutsideRange = limits => complement(validateDate(limits))
 
 const validateVisibleMonths = (currentMonth, months) =>
   times(add(currentMonth), months)
+
+export const isMomentPropValidation = (props, propName) => {
+  const propValue = props[propName]
+
+  if (propValue && !moment.isMoment(propValue)) {
+    return new Error(`Prop ${propName} must be an instance of Moment`)
+  }
+
+  return null
+}
 
 /**
  * Custom calendar based on `react-dates` from airbnb with a simple interface.
@@ -162,11 +173,11 @@ Calendar.propTypes = {
     /**
      * End date based on `moment.js`.
      */
-    end: PropTypes.instanceOf(moment),
+    end: isMomentPropValidation,
     /**
      * Start date based on `moment.js`.
      */
-    start: PropTypes.instanceOf(moment),
+    start: isMomentPropValidation,
   }).isRequired,
   /**
    * This option allows the user to select one date or one priod in the calendar.
@@ -191,11 +202,11 @@ Calendar.propTypes = {
     /**
      * Lowest selectable date based in `moment.js`.
      */
-    lower: PropTypes.instanceOf(moment),
+    lower: isMomentPropValidation,
     /**
      * Biggest selectable date based in `moment.js`.
      */
-    upper: PropTypes.instanceOf(moment),
+    upper: isMomentPropValidation,
   }),
   /**
    * Number of months shown in the calendar.

--- a/src/CalendarInput/index.js
+++ b/src/CalendarInput/index.js
@@ -50,7 +50,7 @@ class CalendarInput extends Component {
     if (process.env.NODE_ENV !== 'test') {
       // eslint-disable-next-line no-console
       console.warn(
-        'CalendarInput component is being deprecated, use DateInput with showCalendar prop as "false" instead.'
+        'CalendarInput component is being deprecated, use DateInput with showSidebar prop as "false" instead.'
       )
     }
 

--- a/src/CalendarInput/index.js
+++ b/src/CalendarInput/index.js
@@ -261,7 +261,7 @@ class CalendarInput extends Component {
 
   isValidDate (date) {
     const { isValidDay } = this.props
-    const isValid = isValidDay ? isValidDay(moment(date)) : true
+    const isValid = isValidDay ? isValidDay(moment(date, 'L')) : true
 
     return !date || (isValid && date)
   }

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -19,7 +19,7 @@ import moment from 'moment'
 import MaskedInput from 'react-maskedinput'
 
 import ThemeConsumer from '../ThemeConsumer'
-import { isMomentPropValidation } from '../Calendar'
+import { isMomentPropValidation } from '../validations'
 import DateSelector, { getPreset, getPresetLimits } from '../DateSelector'
 
 import {

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -20,7 +20,7 @@ import moment from 'moment'
 import MaskedInput from 'react-maskedinput'
 
 import ThemeConsumer from '../ThemeConsumer'
-import DateSelector from '../DateSelector'
+import DateSelector, { getPreset, getPresetLimits } from '../DateSelector'
 
 import {
   inputDateMask,
@@ -60,10 +60,22 @@ class DateInput extends React.Component {
   constructor (props) {
     super(props)
 
+    const presetObject = props.selectedPreset
+      ? getPreset(props.selectedPreset, props.presets)
+      : null
+
+    const dates = presetObject
+      ? momentToText(getPresetLimits(presetObject.date()))
+      : momentToText(props.dates)
+
+    const selectionMode = presetObject
+      ? presetObject.mode
+      : props.selectionMode
+
     this.state = {
-      dates: momentToText(props.dates),
+      dates,
       focusedInput: null,
-      selectionMode: props.selectionMode,
+      selectionMode,
       selectedPreset: props.selectedPreset,
     }
 
@@ -180,7 +192,6 @@ class DateInput extends React.Component {
     })
 
     this.props.onPresetChange(dates, preset)
-    this.props.onChange(dates)
   }
 
   renderInputs () {
@@ -367,7 +378,7 @@ DateInput.propTypes = {
   /**
    * Triggers when DateSelector popover is closed.
    */
-  onConfirm: func.isRequired,
+  onConfirm: func,
   /**
    * Triggers when selected preset is changed.
   */
@@ -440,6 +451,7 @@ DateInput.defaultProps = {
     lower: moment('1900-01-01', 'YYYY-MM-DD'),
     upper: moment('2100-01-01', 'YYYY-MM-DD'),
   },
+  onConfirm: () => null,
   onChange: () => null,
   onPresetChange: () => null,
   presets: [],

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -10,7 +10,6 @@ import {
   bool,
   element,
   func,
-  instanceOf,
   oneOf,
   shape,
   string,
@@ -20,6 +19,7 @@ import moment from 'moment'
 import MaskedInput from 'react-maskedinput'
 
 import ThemeConsumer from '../ThemeConsumer'
+import { isMomentPropValidation } from '../Calendar'
 import DateSelector, { getPreset, getPresetLimits } from '../DateSelector'
 
 import {
@@ -350,8 +350,8 @@ DateInput.propTypes = {
    * Initial dates to be pre selected.
    */
   dates: shape({
-    start: instanceOf(moment),
-    end: instanceOf(moment),
+    start: isMomentPropValidation,
+    end: isMomentPropValidation,
   }),
   /**
    * Custom icon which will be shown in the component left side.
@@ -364,11 +364,11 @@ DateInput.propTypes = {
     /**
      * Lowest selectable date based in `moment.js`.
      */
-    lower: instanceOf(moment),
+    lower: isMomentPropValidation,
     /**
      * Biggest selectable date based in `moment.js`.
      */
-    upper: instanceOf(moment),
+    upper: isMomentPropValidation,
   }),
   /**
    * Triggers when a date is changed or selected.

--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -291,6 +291,7 @@ class DateInput extends React.Component {
   render () {
     const {
       active,
+      isValidDay,
       limits,
       theme,
       presets,
@@ -315,6 +316,7 @@ class DateInput extends React.Component {
       <DateSelector
         dates={isValidDates ? momentDates : {}}
         focusedInput={focusedInput}
+        isValidDay={isValidDay}
         onConfirm={this.handleConfirm}
         onChange={this.handleDatesChange}
         onPresetChange={this.handlePresetChange}
@@ -357,6 +359,10 @@ DateInput.propTypes = {
    * Custom icon which will be shown in the component left side.
    */
   icon: element,
+  /**
+   * Function that returns a boolean wheter the date is valid
+   */
+  isValidDay: func,
   /**
    * Limit dates for range selections.
    */
@@ -447,6 +453,7 @@ DateInput.defaultProps = {
     end: null,
   },
   icon: null,
+  isValidDay: null,
   limits: {
     lower: moment('1900-01-01', 'YYYY-MM-DD'),
     upper: moment('2100-01-01', 'YYYY-MM-DD'),

--- a/src/DateSelector/index.js
+++ b/src/DateSelector/index.js
@@ -65,7 +65,7 @@ const flattenPresets = pipe(
   flatten
 )
 
-const getPreset = (presetName, presets) => {
+export const getPreset = (presetName, presets) => {
   const flattenedPresets = flattenPresets(presets)
   const foundPreset = flattenedPresets
     .find(preset => preset.key === presetName)
@@ -73,7 +73,7 @@ const getPreset = (presetName, presets) => {
   return foundPreset
 }
 
-const getPresetLimits = (range) => {
+export const getPresetLimits = (range) => {
   // TODO: refactor range logic be based on
   // selected date instead of current date
 

--- a/src/DateSelector/index.js
+++ b/src/DateSelector/index.js
@@ -200,6 +200,7 @@ class DateSelector extends Component {
       dates,
       focusedInput,
       icons,
+      isValidDay,
       presets,
       selectedPreset,
       selectionMode,
@@ -219,7 +220,10 @@ class DateSelector extends Component {
         <Calendar
           numberOfMonths={2}
           daySize={40}
-          isDayBlocked={date => isDayBlocked(date, presetRange, presetLimits)}
+          isDayBlocked={date =>
+            (isValidDay && !isValidDay(date))
+            || isDayBlocked(date, presetRange, presetLimits)
+          }
           navPrev={icons.previousMonth}
           navNext={icons.nextMonth}
           dates={{
@@ -354,6 +358,10 @@ DateSelector.propTypes = {
     nextMonth: element,
   }),
   /**
+   * Function that returns a boolean wheter the date is valid
+   */
+  isValidDay: func,
+  /**
    * Mode to be used when showSidebar is false.
   */
   selectionMode: (props, propName) => {
@@ -439,6 +447,7 @@ DateSelector.defaultProps = {
   selectedPreset: '',
   focusedInput: null,
   icons: {},
+  isValidDay: null,
   selectionMode: 'single',
   onPresetChange: () => undefined,
   presets: [],

--- a/src/DateSelector/index.js
+++ b/src/DateSelector/index.js
@@ -8,8 +8,6 @@ import {
   arrayOf,
   shape,
   oneOf,
-  oneOfType,
-  object,
   element,
 } from 'prop-types'
 import shortid from 'shortid'
@@ -24,7 +22,6 @@ import {
   pipe,
   prop,
 } from 'ramda'
-import { momentObj } from 'react-moment-proptypes'
 import moment from 'moment'
 
 import ThemeConsumer from '../ThemeConsumer'
@@ -33,7 +30,7 @@ import normalizeDates from './normalizeDates'
 import {
   Popover,
 } from '../Popover'
-import Calendar from '../Calendar'
+import Calendar, { isMomentPropValidation } from '../Calendar'
 import Aside from './Aside'
 
 const consumeTheme = ThemeConsumer('UIDateSelector')
@@ -343,11 +340,11 @@ DateSelector.propTypes = {
     /**
      * Start date based on `moment.js`.
      */
-    start: oneOfType([momentObj, object]),
+    start: isMomentPropValidation,
     /**
      * End date based on `moment.js`.
      */
-    end: oneOfType([momentObj, object]),
+    end: isMomentPropValidation,
   }),
   /**
    * Default icons used in the month navigation.

--- a/src/DateSelector/index.js
+++ b/src/DateSelector/index.js
@@ -30,7 +30,8 @@ import normalizeDates from './normalizeDates'
 import {
   Popover,
 } from '../Popover'
-import Calendar, { isMomentPropValidation } from '../Calendar'
+import Calendar from '../Calendar'
+import isMomentPropValidation from '../validations'
 import Aside from './Aside'
 
 const consumeTheme = ThemeConsumer('UIDateSelector')

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ export { default as ThemeProvider } from './ThemeProvider'
 export { default as Tooltip } from './Tooltip'
 export { default as Typeset } from './Typeset'
 
+export * from './validations'
 export * from './Card'
 export * from './Grid'
 export * from './Header'

--- a/src/validations/index.js
+++ b/src/validations/index.js
@@ -1,0 +1,3 @@
+// remove this lint disable comment when another validation is added
+// eslint-disable-next-line
+export { default as isMomentPropValidation } from './momentProp'

--- a/src/validations/momentProp.js
+++ b/src/validations/momentProp.js
@@ -1,0 +1,11 @@
+import { isMoment } from 'moment'
+
+export default (props, propName) => {
+  const propValue = props[propName]
+
+  if (propValue && !isMoment(propValue)) {
+    return new Error(`Prop ${propName} must be an instance of Moment`)
+  }
+
+  return null
+}

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -11272,14 +11272,41 @@ exports[`Storyshots DateInput with sidebar and selected preset 1`] = `
                 onKeyDown={[Function]}
                 onKeyPress={[Function]}
                 onPaste={[Function]}
-                placeholder="Start"
+                placeholder="09/23/2017"
                 size="8"
-                value=""
+                value="09/23/2017"
               />
               <span
                 className="expander"
               >
-                Start
+                09/23/2017
+              </span>
+            </div>
+            <div
+              className="separator"
+            />
+            <div
+              className="end"
+            >
+              <input
+                autoComplete="off"
+                className="input"
+                mask="11/11/1111"
+                maxLength={10}
+                name="endDate"
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onPaste={[Function]}
+                placeholder="End"
+                size="8"
+                value="09/30/2017"
+              />
+              <span
+                className="expander"
+              >
+                09/30/2017
               </span>
             </div>
           </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -11885,13 +11885,6 @@ react-modal@3.8.1, react-modal@^3.6.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-moment-proptypes@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/react-moment-proptypes/-/react-moment-proptypes-1.5.0.tgz#4a448cd6479efc5dd509283f361f3753c3abe60e"
-  integrity sha512-0dQJNs0aaiMeGp1AJACDTzGMM7N4qv4Wgg1948/ARdLt3VKlkcem6Yjm5ExUmUtoXk6WpSXvFQ204l7E+RTEEQ==
-  dependencies:
-    moment ">=1.6.0"
-
 react-moment-proptypes@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/react-moment-proptypes/-/react-moment-proptypes-1.6.0.tgz#8ec266ee392a08ba3412d2df2eebf833ab1046df"


### PR DESCRIPTION
## Context
Ao utilizar o DateInput com a prop `selectedPreset`, o preset é selecionado mas a sua data não é inserida no input de texto. Este PR soluciona este problema.

## Checklist
- [x] Ao utilizar a prop `selectedPreset`, a data do range do preset deve ser inserida nos inputs de texto
- [x] Adicionada a prop `isValidDay` no DateInput e no DateSelector para podermos bloquear dias não úteis
- [x] Corrige a validação de props do Moment

**Solves:** https://github.com/pagarme/former-kit/issues/235