### PR TITLE
table-loader-row: update colspan handlers

### DIFF
--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -169,6 +169,23 @@ const getRowTotal = (row, column, total) => {
   return null
 }
 
+const getColSpan = ({
+  columns,
+  expandable,
+  maxColumns,
+}) => {
+  if (maxColumns < columns.length) {
+    if (expandable) {
+      return maxColumns + 1
+    }
+
+    return maxColumns
+  }
+
+  const extraColumnLength = columns.length + 1
+  return expandable ? extraColumnLength : columns.length
+}
+
 /**
  * This component is designed to show tabular data with some customizations,
  * allowing the user to sort, select and click rows, also show rows details
@@ -312,21 +329,22 @@ class Table extends Component {
 
   renderLoadingRow () {
     const {
-      columns,
-      rows,
       loaderRenderer,
+      rows,
     } = this.props
+
+    const colSpan = getColSpan(this.props)
 
     if (isNil(loaderRenderer)) {
       return (
-        <TableLoadingRow colSpan={columns.length} />
+        <TableLoadingRow colSpan={colSpan} />
       )
     }
 
     return times(key => (
       <TableLoadingRow
         key={key}
-        colSpan={columns.length}
+        colSpan={colSpan}
         renderer={loaderRenderer}
       />
     ), rows.length)


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->

## Context
The `TableLoaderRow` component handle with `colSpan` in a wrong way ignoring the `maxColumns` and `expandable` props.

This PR fix this by considering these props.

## Checklist
- [ ] Render the loader row without break thead.
<!-- Describe the main changes that your PR does. -->

Related #249 