### PR TITLE
chore: update range version from package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-click-outside": "3.0.1",
     "react-dates": "18.4.1",
     "react-dom": "16.7.0",
-    "react-input-mask": "^2.0.4",
+    "react-input-mask": "2.0.4",
     "react-maskedinput": "4.0.1",
     "react-modal": "3.8.1",
     "react-motion": "0.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11840,7 +11840,7 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
-react-input-mask@^2.0.4:
+react-input-mask@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-input-mask/-/react-input-mask-2.0.4.tgz#9ade5cf8196f4a856dbf010820fe75a795f3eb14"
   integrity sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==


### PR DESCRIPTION
## Context
This PR remove `ˆ` from `react-input-mask` dependency.

Resolve #245 