### PR TITLE
date-input: add moment peer dependency and add mask prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
     "prebuild": "rimraf ./dist",
     "prepublish": "npm run build"
   },
+  "peerDependencies": {
+    "moment": "^2.24.0"
+  },
   "dependencies": {
     "classnames": "2.2.6",
     "emblematic-icons": "0.6.1",
     "former-kit-skin-pagarme": "1.1.0",
-    "moment": "2.24.0",
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",
@@ -92,6 +94,7 @@
     "jest-cli": "23.6.0",
     "jest-in-case": "1.0.2",
     "mockdate": "2.0.2",
+    "moment": "2.24.0",
     "npm-run-all": "4.1.2",
     "nyc": "13.1.0",
     "object-assign": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9553,7 +9553,7 @@ mockdate@2.0.2:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
   integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
 
-moment@>=1.6.0:
+moment@2.24.0, moment@>=1.6.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9553,7 +9553,7 @@ mockdate@2.0.2:
   resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
   integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
 
-moment@2.24.0, moment@>=1.6.0:
+moment@>=1.6.0:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
## Contexto
This PR fixes MM/DD/YYYY to DD/MM/YYYY.

## Checklist
- [ ] Show format dates `DD/MM/YYYY` to `MM/DD/YYYY`

## Linked Issues
- [x] Resolves https://github.com/pagarme/pilot/issues/972
- [x] Resolves https://github.com/pagarme/pilot/issues/1151

## How to test?
- Go to `fix/anticipation-moment-js` branch
- Generate a link to `former-kit` repository
- Go to Pilot and run `yarn link former-kit`
- Run Pilot locally and see with the problem persists. If don't persist, that's it! :tada: 

## New Peer Dependencies and Dev Dependencies
```
  "moment": "^2.24.0"
```