### PR TITLE
Release 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "emblematic-icons": "0.6.1",
-    "former-kit-skin-pagarme": "1.3.0",
+    "former-kit-skin-pagarme": "1.3.2",
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6321,10 +6321,10 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-former-kit-skin-pagarme@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.3.0.tgz#05bdd1f8e9b91c4a8c767e46e336e899f7d71c74"
-  integrity sha512-5N+EcazvwHabG4Cy6BXK18lGqPhpvLWhd7obQaokniQmpVW2abDyatsbQ1X6VbeYWZx8ubSIPRoPi14IFiAQmw==
+former-kit-skin-pagarme@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.3.2.tgz#cc6711f40dff84c0c0e1ecfc902fe680dc0295c1"
+  integrity sha512-PLONRUhYHhmaIWYgVYlZWf2ZTSWurdgxv34CqvZB9hgTkh8oVn02azWG4SNS1mdqLNuzq6BLJD5FHsdO7w8t+g==
   dependencies:
     emblematic-icons "0.6.1"
     react-dates "18.4.0"


### PR DESCRIPTION
This releases includes:
- Tooltip: Add classname prop #266
- bump dependency `former-kit-skin-pagarme` from `1.3.0` to `1.3.2`

## Linked Issues
- Resolves #268