### PR TITLE
Add a new props to Modal component: size

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,7 @@ module.exports = {
   transform: {
     "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest",
     "^.+\\.css$": "<rootDir>/config/jest/cssTransform.js",
-    "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js"
+    "^(?!.*\\.(js|jsx|css|json)$)": "<rootDir>/config/jest/fileTransform.js",
   },
   transformIgnorePatterns: [
     "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 import ReactModal from 'react-modal'
 import ThemeConsumer from '../ThemeConsumer'
 
@@ -15,29 +16,37 @@ const Modal = ({
   children,
   isOpen,
   onRequestClose,
+  size,
   theme,
-}) => (
-  <ReactModal
-    appElement={document.body}
-    className={{
-      afterOpen: theme.modalAfterOpen,
-      base: theme.modal,
-      beforeClose: theme.modalBeforeClose,
-    }}
-    closeTimeoutMS={200}
-    isOpen={isOpen}
-    onRequestClose={onRequestClose}
-    overlayClassName={{
-      afterOpen: theme.overlayAfterOpen,
-      base: theme.overlay,
-      beforeClose: theme.overlayBeforeClose,
-    }}
-    parentSelector={() => document.body}
-    role="dialog"
-  >
-    {children}
-  </ReactModal>
-)
+}) => {
+  const modalClasses = classNames(
+    theme.modal,
+    theme[size]
+  )
+
+  return (
+    <ReactModal
+      appElement={document.body}
+      className={{
+        afterOpen: theme.modalAfterOpen,
+        base: modalClasses,
+        beforeClose: theme.modalBeforeClose,
+      }}
+      closeTimeoutMS={200}
+      isOpen={isOpen}
+      onRequestClose={onRequestClose}
+      overlayClassName={{
+        afterOpen: theme.overlayAfterOpen,
+        base: theme.overlay,
+        beforeClose: theme.overlayBeforeClose,
+      }}
+      parentSelector={() => document.body}
+      role="dialog"
+    >
+      {children}
+    </ReactModal>
+  )
+}
 
 Modal.propTypes = {
   /**
@@ -54,6 +63,12 @@ Modal.propTypes = {
    */
   onRequestClose: PropTypes.func,
   /**
+   * Component's size.
+   */
+  size: PropTypes.oneOf([
+    'default', 'huge',
+  ]),
+  /**
    * @see [ThemeProvider](#themeprovider) - Theme received from `consumeTheme` wrapper.
    */
   theme: PropTypes.shape({
@@ -64,11 +79,13 @@ Modal.propTypes = {
     overlay: PropTypes.string,
     overlayAfterOpen: PropTypes.string,
     overlayBeforeClose: PropTypes.string,
+    size: PropTypes.string,
   }),
 }
 
 Modal.defaultProps = {
   onRequestClose: null,
+  size: 'default',
   theme: {
     frame: '',
     modal: '',

--- a/src/Modal/Modal.md
+++ b/src/Modal/Modal.md
@@ -35,3 +35,13 @@ const ModalWithState = require('./examples/ModalWithState').default;
   withSection
 />
 ```
+
+Modal with huge size
+``` jsx
+const ModalWithState = require('./examples/ModalWithState').default;
+<ModalWithState
+  completeTitle
+  message="Modal with all features"
+  size="huge"
+/>
+```

--- a/src/Modal/examples/ModalWithState.js
+++ b/src/Modal/examples/ModalWithState.js
@@ -36,6 +36,7 @@ class ModalWithState extends Component {
     const {
       completeTitle,
       message,
+      size,
       title,
       withActions,
       withSection,
@@ -57,6 +58,7 @@ class ModalWithState extends Component {
           isOpen={isOpen}
           label="Create a Transaction"
           onRequestClose={this.handleToggleModal}
+          size={size}
         >
           {completeTitle
             ? (
@@ -113,6 +115,7 @@ class ModalWithState extends Component {
 ModalWithState.propTypes = {
   completeTitle: PropTypes.bool,
   message: PropTypes.string,
+  size: PropTypes.string,
   title: PropTypes.string,
   withActions: PropTypes.bool,
   withSection: PropTypes.bool,
@@ -121,6 +124,7 @@ ModalWithState.propTypes = {
 ModalWithState.defaultProps = {
   completeTitle: false,
   message: 'This is the modal Content with React Modal module',
+  size: 'default',
   title: 'Add photo',
   withActions: false,
   withSection: false,

--- a/stories/Modal/ModalWithHugeSize.js
+++ b/stories/Modal/ModalWithHugeSize.js
@@ -1,0 +1,95 @@
+import React, { Component } from 'react'
+import IconClose from 'emblematic-icons/svg/ClearClose32.svg'
+
+import {
+  Modal,
+  ModalActions,
+  ModalContent,
+  ModalSection,
+  ModalTitle,
+} from '../../src/Modal'
+
+import Button from '../../src/Button'
+
+class ModalWithState extends Component {
+  constructor () {
+    super()
+
+    this.state = {
+      isOpen: false,
+    }
+
+    this.handleToggleModal = this.handleToggleModal.bind(this)
+    this.handleCloseModal = this.handleCloseModal.bind(this)
+  }
+
+  handleToggleModal () {
+    const { isOpen } = this.state
+    this.setState({ isOpen: !isOpen })
+  }
+
+  handleCloseModal () {
+    this.setState({ isOpen: false })
+  }
+
+  render () {
+    const { isOpen } = this.state
+
+    return (
+      <div>
+        {/* call to action to open the modal */}
+        <Button
+          fill="flat"
+          relevance="low"
+          onClick={this.handleToggleModal}
+        >
+          Modal with huge size
+        </Button>
+
+        {/* modal content definition */}
+        <Modal
+          label="Create a Transaction"
+          isOpen={isOpen}
+          onRequestClose={this.handleToggleModal}
+          size="huge"
+        >
+          <ModalTitle
+            closeIcon={<IconClose width={16} height={16} />}
+            onClose={this.handleCloseModal}
+            title="Modal With Huge Size"
+          />
+          <hr />
+          <ModalContent>
+            This is the modal Content with React Modal module
+          </ModalContent>
+
+          <ModalContent>
+            <ModalSection>
+              <ModalContent>
+                This is the modal Section
+              </ModalContent>
+            </ModalSection>
+          </ModalContent>
+          <ModalActions>
+            <Button
+              fill="outline"
+              size="default"
+              onClick={this.handleToggleModal}
+            >
+              Cancel
+            </Button>
+
+            <Button
+              size="default"
+              onClick={this.handleToggleModal}
+            >
+              Confirm
+            </Button>
+          </ModalActions>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalWithState

--- a/stories/Modal/ModalWithState.js
+++ b/stories/Modal/ModalWithState.js
@@ -1,0 +1,97 @@
+import React, { Component } from 'react'
+import IconAddPhoto from 'emblematic-icons/svg/Camera32.svg'
+import IconClose from 'emblematic-icons/svg/ClearClose32.svg'
+
+import {
+  Modal,
+  ModalActions,
+  ModalContent,
+  ModalSection,
+  ModalTitle,
+} from '../../src/Modal'
+
+import Button from '../../src/Button'
+
+class ModalWithState extends Component {
+  constructor () {
+    super()
+
+    this.state = {
+      isOpen: false,
+    }
+
+    this.handleToggleModal = this.handleToggleModal.bind(this)
+    this.handleCloseModal = this.handleCloseModal.bind(this)
+  }
+
+  handleToggleModal () {
+    const { isOpen } = this.state
+    this.setState({ isOpen: !isOpen })
+  }
+
+  handleCloseModal () {
+    this.setState({ isOpen: false })
+  }
+
+  render () {
+    const { isOpen } = this.state
+
+    return (
+      <div>
+        {/* call to action to open the modal */}
+        <Button
+          fill="flat"
+          relevance="low"
+          onClick={this.handleToggleModal}
+          icon={<IconAddPhoto width={16} height={16} />}
+        >
+          Add Photo
+        </Button>
+
+        {/* modal content definition */}
+        <Modal
+          label="Create a Transaction"
+          isOpen={isOpen}
+          onRequestClose={this.handleToggleModal}
+        >
+          <ModalTitle
+            closeIcon={<IconClose width={16} height={16} />}
+            icon={<IconAddPhoto width={16} height={16} />}
+            onClose={this.handleCloseModal}
+            title="Add Photo"
+          />
+          <hr />
+          <ModalContent>
+            This is the modal Content with React Modal module
+          </ModalContent>
+
+          <ModalContent>
+            <ModalSection>
+              <ModalContent>
+                This is the modal Section
+              </ModalContent>
+            </ModalSection>
+          </ModalContent>
+          <ModalActions>
+            <Button
+              fill="outline"
+              size="default"
+              onClick={this.handleToggleModal}
+            >
+              Cancel
+            </Button>
+
+            <Button
+              size="default"
+              onClick={this.handleToggleModal}
+            >
+              Confirm
+            </Button>
+          </ModalActions>
+        </Modal>
+      </div>
+    )
+  }
+}
+
+export default ModalWithState

--- a/stories/Modal/index.js
+++ b/stories/Modal/index.js
@@ -1,105 +1,20 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import IconAddPhoto from 'emblematic-icons/svg/Camera32.svg'
-import IconClose from 'emblematic-icons/svg/ClearClose32.svg'
 import Section from '../Section'
 
-import {
-  Modal,
-  ModalActions,
-  ModalContent,
-  ModalSection,
-  ModalTitle,
-} from '../../src/Modal'
-
-import Button from '../../src/Button'
-
-class ModalWithState extends Component {
-  constructor () {
-    super()
-
-    this.state = {
-      isOpen: true,
-    }
-
-    this.handleToggleModal = this.handleToggleModal.bind(this)
-    this.handleCloseModal = this.handleCloseModal.bind(this)
-  }
-
-  handleToggleModal () {
-    const { isOpen } = this.state
-    this.setState({ isOpen: !isOpen })
-  }
-
-  handleCloseModal () {
-    this.setState({ isOpen: false })
-  }
-
-  render () {
-    const { isOpen } = this.state
-
-    return (
-      <div>
-        {/* call to action to open the modal */}
-        <Button
-          fill="flat"
-          relevance="low"
-          onClick={this.handleToggleModal}
-          icon={<IconAddPhoto width={16} height={16} />}
-        >
-          Add Photo
-        </Button>
-
-        {/* modal content definition */}
-        <Modal
-          label="Create a Transaction"
-          isOpen={isOpen}
-          onRequestClose={this.handleToggleModal}
-        >
-          <ModalTitle
-            closeIcon={<IconClose width={16} height={16} />}
-            icon={<IconAddPhoto width={16} height={16} />}
-            onClose={this.handleCloseModal}
-            title="Add Photo"
-          />
-          <hr />
-          <ModalContent>
-            This is the modal Content with React Modal module
-          </ModalContent>
-
-          <ModalContent>
-            <ModalSection>
-              <ModalContent>
-                This is the modal Section
-              </ModalContent>
-            </ModalSection>
-          </ModalContent>
-          <ModalActions>
-            <Button
-              fill="outline"
-              size="default"
-              onClick={this.handleToggleModal}
-            >
-              Cancel
-            </Button>
-
-            <Button
-              size="default"
-              onClick={this.handleToggleModal}
-            >
-              Confirm
-            </Button>
-          </ModalActions>
-        </Modal>
-      </div>
-    )
-  }
-}
+import ModalWithState from './ModalWithState'
+import ModalWithHugeSize from './ModalWithHugeSize'
 
 storiesOf('Modal', module)
   .add('Default', () => (
-    <Section>
-      <ModalWithState />
-    </Section>
+    <div>
+      <Section>
+        <ModalWithState />
+      </Section>
+      <Section>
+        <ModalWithHugeSize />
+      </Section>
+    </div>
   ))
+

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -25198,148 +25198,282 @@ exports[`Storyshots Modal Default 1`] = `
 <div
   className="storybook-readme-story"
 >
-  <section
+  <div
     className="typography"
   >
-    
-    <div>
+    <section
+      className=""
+    >
+      
       <div>
-        <button
-          className="button flat lowRelevance default"
-          disabled={false}
-          onClick={[Function]}
-          type="button"
-        >
-          <Camera32.svg
-            height={16}
-            width={16}
-          />
-          <span>
-            Add Photo
-          </span>
-          <span
-            className="ripple"
-            style={
-              Object {
-                "height": 0,
-                "left": 0,
-                "top": 0,
-                "width": 0,
-              }
-            }
-          />
-        </button>
-        <div
-          className="modal"
-        >
-          <div
-            className="title"
+        <div>
+          <button
+            className="button flat lowRelevance default"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
           >
-            <div
-              className="icon"
-            >
-              <Camera32.svg
-                height={16}
-                width={16}
-              />
-            </div>
-            <h2
-              className="centerAlign"
-            >
+            <Camera32.svg
+              height={16}
+              width={16}
+            />
+            <span>
               Add Photo
-            </h2>
-            <button
-              className="button clean lowRelevance tiny iconButton"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <ClearClose32.svg
-                height={16}
-                width={16}
-              />
-              <span
-                className="ripple"
-                style={
-                  Object {
-                    "height": 0,
-                    "left": 0,
-                    "top": 0,
-                    "width": 0,
-                  }
+            </span>
+            <span
+              className="ripple"
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
                 }
-              />
-            </button>
-          </div>
-          <hr />
+              }
+            />
+          </button>
           <div
-            className="content"
-          >
-            This is the modal Content with React Modal module
-          </div>
-          <div
-            className="content"
+            className="modal"
           >
             <div
-              className="section"
+              className="title"
             >
               <div
-                className="content"
+                className="icon"
               >
-                This is the modal Section
+                <Camera32.svg
+                  height={16}
+                  width={16}
+                />
+              </div>
+              <h2
+                className="centerAlign"
+              >
+                Add Photo
+              </h2>
+              <button
+                className="button clean lowRelevance tiny iconButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <ClearClose32.svg
+                  height={16}
+                  width={16}
+                />
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
+                  }
+                />
+              </button>
+            </div>
+            <hr />
+            <div
+              className="content"
+            >
+              This is the modal Content with React Modal module
+            </div>
+            <div
+              className="content"
+            >
+              <div
+                className="section"
+              >
+                <div
+                  className="content"
+                >
+                  This is the modal Section
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            className="actions"
-          >
-            <button
-              className="button outline normalRelevance default"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
+            <div
+              className="actions"
             >
-              <span>
-                Cancel
-              </span>
-              <span
-                className="ripple"
-                style={
-                  Object {
-                    "height": 0,
-                    "left": 0,
-                    "top": 0,
-                    "width": 0,
+              <button
+                className="button outline normalRelevance default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
                   }
-                }
-              />
-            </button>
-            <button
-              className="button flat normalRelevance default"
-              disabled={false}
-              onClick={[Function]}
-              type="button"
-            >
-              <span>
-                Confirm
-              </span>
-              <span
-                className="ripple"
-                style={
-                  Object {
-                    "height": 0,
-                    "left": 0,
-                    "top": 0,
-                    "width": 0,
+                />
+              </button>
+              <button
+                className="button flat normalRelevance default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span>
+                  Confirm
+                </span>
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
                   }
-                }
-              />
-            </button>
+                />
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </section>
+    </section>
+    <section
+      className=""
+    >
+      
+      <div>
+        <div>
+          <button
+            className="button flat lowRelevance default"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Modal with huge size
+            </span>
+            <span
+              className="ripple"
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </button>
+          <div
+            className="modal"
+          >
+            <div
+              className="title"
+            >
+              <h2
+                className="centerAlign"
+              >
+                Modal With Huge Size
+              </h2>
+              <button
+                className="button clean lowRelevance tiny iconButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <ClearClose32.svg
+                  height={16}
+                  width={16}
+                />
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
+                  }
+                />
+              </button>
+            </div>
+            <hr />
+            <div
+              className="content"
+            >
+              This is the modal Content with React Modal module
+            </div>
+            <div
+              className="content"
+            >
+              <div
+                className="section"
+              >
+                <div
+                  className="content"
+                >
+                  This is the modal Section
+                </div>
+              </div>
+            </div>
+            <div
+              className="actions"
+            >
+              <button
+                className="button outline normalRelevance default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
+                  }
+                />
+              </button>
+              <button
+                className="button flat normalRelevance default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span>
+                  Confirm
+                </span>
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
+                  }
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
## Context
This PR adds a new props to the Modal component called `size`. This new props will control the width of the Modal component and have two parameters: `default` and `huge`

## Linked Issues
- [x] This PR was opened in parallel with this: https://github.com/pagarme/former-kit-skin-pagarme/pull/182

## Screenshots
<!-- Add some images to have a preview of your task, to help developers and designers to undestand easily which you're working on. -->
![image](https://user-images.githubusercontent.com/20197808/59300172-e3530d80-8c64-11e9-90f1-7977d3791ee0.png)

## How to test:
- `git clone` in this repo
- `yarn` to install dependencies
- `yarn link` to link `former-kit-skin-pagarme` if it is not updated
- `yarn storybook` to run local
