### PR TITLE
Table PR: add condition to control sizes in recipients table

### DIFF
--- a/src/Table/TableHead.js
+++ b/src/Table/TableHead.js
@@ -63,6 +63,7 @@ class TableHead extends Component {
     isAction,
     orderable,
     title,
+    width,
   },
   index) {
     const {
@@ -84,11 +85,18 @@ class TableHead extends Component {
       }
     )
 
+    const thStyle = {}
+
+    if (width) {
+      thStyle.width = `${width}px`
+    }
+
     if (!orderable || not(onOrderChange)) {
       return (
         <th
           key={`header_column_${index + 1}`}
           className={columnClasses}
+          style={thStyle}
         >
           <div
             className={classNames(
@@ -113,6 +121,7 @@ class TableHead extends Component {
         key={`column_${index + 1}`}
         className={columnClasses}
         {...thProps}
+        style={thStyle}
       >
         <div className={theme.tableHeadItem}>
           <span> {title} </span>
@@ -221,6 +230,10 @@ TableHead.propTypes = {
      * column data in the expandable rows.
      */
     title: string.isRequired,
+    /**
+     * Defines the column width in pixels
+     */
+    width: number,
   })).isRequired,
   /**
    * It disables the click on orderable columns.

--- a/src/Table/examples/TableState.js
+++ b/src/Table/examples/TableState.js
@@ -38,6 +38,11 @@ const getRowsSort = (rows, columns) => (orderColumn, order) => {
   return sort(rows)
 }
 
+const addSizeProp = list => list.map((column, i) => ({
+  ...column,
+  width: i % 2 === 0 ? 80 : 200,
+}))
+
 class TableState extends Component {
   constructor (props) {
     super(props)
@@ -48,7 +53,11 @@ class TableState extends Component {
     this.handleExpandRow = this.handleExpandRow.bind(this)
     this.handleOrderChange = this.handleOrderChange.bind(this)
     this.handleSelectRow = this.handleSelectRow.bind(this)
-    this.mock = getMock(this.handleDetailsClick)
+    const mock = getMock(this.handleDetailsClick)
+    this.mock = {
+      ...mock,
+      columns: addSizeProp(mock.columns),
+    }
     this.state = {
       columns: this.getColumns(props.primaryAction),
       expandedRows: [],

--- a/src/Table/index.js
+++ b/src/Table/index.js
@@ -557,6 +557,10 @@ Table.propTypes = {
      * column data in the expandable rows.
      */
     title: string.isRequired,
+    /**
+     * Defines the column width in pixels
+     */
+    width: number,
   })).isRequired,
   /**
    * It disables all table functions.

--- a/src/Table/tests/Table.static.test.js
+++ b/src/Table/tests/Table.static.test.js
@@ -150,6 +150,7 @@ describe('Table', () => {
           const { component } = createComponents({
             columns: columnsWithWidthProps,
           })
+
           const firstRow = component.find(TableRow).first()
           const header = component.find(TableHead)
           let lastColumn = firstRow

--- a/src/Table/tests/Table.static.test.js
+++ b/src/Table/tests/Table.static.test.js
@@ -14,7 +14,10 @@ import TableEmptyItem from '../TableEmptyItem'
 import TableEmptyRow from '../TableEmptyRow'
 import TableHead from '../TableHead'
 import TableRow from '../TableRow'
-import { createComponents } from './common'
+import {
+  createComponents,
+  mock,
+} from './common'
 import {
   columnsCases,
   rowsCases,
@@ -133,6 +136,30 @@ describe('Table', () => {
 
           expect(lastColumn.exists()).toBe(true)
           expect(lastColumn.children().exists()).toBe(true)
+        })
+      })
+
+      describe('should control columns width correctly', () => {
+        it('when a width prop is received', () => {
+          const { columns } = mock
+          const columnsWithWidthProps = columns.map(column => ({
+            ...column,
+            width: 120,
+          }))
+
+          const { component } = createComponents({
+            columns: columnsWithWidthProps,
+          })
+          const firstRow = component.find(TableRow).first()
+          const header = component.find(TableHead)
+          let lastColumn = firstRow
+
+          lastColumn = header
+            .find('th[style]')
+            .last()
+
+          expect(lastColumn.exists()).toBe(true)
+          expect(lastColumn.prop('style').width).toBe('120px')
         })
       })
 

--- a/src/Table/tests/common.js
+++ b/src/Table/tests/common.js
@@ -223,4 +223,5 @@ const createComponents = ({
 export {
   columnWithRenderer,
   createComponents,
+  mock,
 }

--- a/stories/Table/TableState.js
+++ b/stories/Table/TableState.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { Component } from 'react'
 import { bool } from 'prop-types'
 import {
@@ -47,11 +46,6 @@ const formatSimpleTableColumns = map(
   assoc('orderable', false)
 )
 
-const addSizeProp = list => list.map((column, i) => ({
-  ...column,
-  width: i % 2 === 0 ? 80 : 200,
-}))
-
 class TableState extends Component {
   constructor (props) {
     super(props)
@@ -73,12 +67,7 @@ class TableState extends Component {
     this.getColumnsWithPrimaryAction = this
       .getColumnsWithPrimaryAction
       .bind(this)
-
-    const mock = getMock(this.handleDetailsClick, disabled)
-    this.mock = {
-      ...mock,
-      columns: addSizeProp(mock.columns),
-    }
+    this.mock = getMock(this.handleDetailsClick, disabled)
 
     this.state = {
       columns: this.getColumns(primaryAction, simple),

--- a/stories/Table/TableState.js
+++ b/stories/Table/TableState.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 import React, { Component } from 'react'
 import { bool } from 'prop-types'
 import {
@@ -46,6 +47,11 @@ const formatSimpleTableColumns = map(
   assoc('orderable', false)
 )
 
+const addSizeProp = list => list.map((column, i) => ({
+  ...column,
+  width: i % 2 === 0 ? 80 : 200,
+}))
+
 class TableState extends Component {
   constructor (props) {
     super(props)
@@ -67,7 +73,13 @@ class TableState extends Component {
     this.getColumnsWithPrimaryAction = this
       .getColumnsWithPrimaryAction
       .bind(this)
-    this.mock = getMock(this.handleDetailsClick, disabled)
+
+    const mock = getMock(this.handleDetailsClick, disabled)
+    this.mock = {
+      ...mock,
+      columns: addSizeProp(mock.columns),
+    }
+
     this.state = {
       columns: this.getColumns(primaryAction, simple),
       detailsClicks: 0,

--- a/stories/Table/TableStateWidthControl.js
+++ b/stories/Table/TableStateWidthControl.js
@@ -1,0 +1,132 @@
+import React, { Component, Fragment } from 'react'
+
+import SegmentedSwitch from '../../src/SegmentedSwitch'
+import Table from '../../src/Table'
+import style from './style.css'
+
+import getMock from './tableMock'
+
+const addSizeProp = (column, i) => ({
+  ...column,
+  orderable: false,
+  width: i % 2 === 0 ? 80 : 200,
+})
+
+const addSameSizeProp = column => ({
+  ...column,
+  orderable: false,
+  width: 120,
+})
+
+const options = [
+  {
+    title: 'Same size columns',
+    value: 'noSize',
+  },
+  {
+    title: 'Columns with different sizes',
+    value: 'sizedColumns',
+  },
+]
+
+class TableStateWidthControl extends Component {
+  constructor (props) {
+    super(props)
+
+    const {
+      selectable,
+    } = props
+
+    const mock = getMock()
+    this.mock = {
+      ...mock,
+      columns: mock.columns.map(addSizeProp),
+    }
+
+    this.handleChange = this.handleChange.bind(this)
+    this.handleColumnsToSameWidth = this.handleColumnsToSameWidth.bind(this)
+    this.handleColumnsToDistinctsWidth = this.handleColumnsToDistinctsWidth
+      .bind(this)
+
+    this.state = {
+      columns: this.mock.columns,
+      rows: this.mock.rows,
+      selectedRows: selectable ? [2] : [],
+      value: 'sizedColumns',
+    }
+  }
+
+  handleColumnsToSameWidth () {
+    const { columns } = this.state
+    const mock = getMock()
+
+    this.mock = {
+      ...mock,
+      columns: columns.map(addSameSizeProp),
+    }
+
+    this.setState({
+      columns: this.mock.columns,
+    })
+  }
+
+  handleColumnsToDistinctsWidth () {
+    const { columns } = this.state
+
+    const mock = getMock()
+    this.mock = {
+      ...mock,
+      columns: columns.map(addSizeProp),
+    }
+
+    this.setState({
+      columns: this.mock.columns,
+    })
+  }
+
+  handleChange (value, primaryAction, simple) {
+    this.setState({
+      value,
+    })
+
+    if (value === 'noSize') {
+      return this.handleColumnsToSameWidth(primaryAction, simple)
+    }
+
+    return this.handleColumnsToDistinctsWidth(primaryAction, simple)
+  }
+
+  render () {
+    const {
+      columns,
+      rows,
+      selectedRows,
+      value,
+    } = this.state
+
+    return (
+      <Fragment>
+        <Table
+          className={style.table}
+          columns={columns}
+          disabled={false}
+          maxColumns={7}
+          onOrderChange
+          rows={rows}
+          selectable={false}
+          selectedRows={selectedRows}
+        />
+
+        <br />
+        <SegmentedSwitch
+          name="table-test"
+          options={options}
+          onChange={this.handleChange}
+          value={value}
+        />
+      </Fragment>
+    )
+  }
+}
+
+export default TableStateWidthControl

--- a/stories/Table/index.js
+++ b/stories/Table/index.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react'
 
 import TableState from './TableState'
 import TableStateLoading from './TableStateLoading'
+import TableStateWidthControl from './TableStateWidthControl'
 import Section from '../Section'
 
 storiesOf('Table', module)
@@ -53,5 +54,10 @@ storiesOf('Table', module)
   .add('Loading rows', () => (
     <Section>
       <TableStateLoading />
+    </Section>
+  ))
+  .add('Width Control', () => (
+    <Section>
+      <TableStateWidthControl />
     </Section>
   ))

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -31687,6 +31687,7 @@ exports[`Storyshots Table Action column 1`] = `
               <th
                 className="active orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -31706,6 +31707,7 @@ exports[`Storyshots Table Action column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -31725,6 +31727,7 @@ exports[`Storyshots Table Action column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -31744,6 +31747,7 @@ exports[`Storyshots Table Action column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -31763,6 +31767,7 @@ exports[`Storyshots Table Action column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -31782,6 +31787,7 @@ exports[`Storyshots Table Action column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -31800,6 +31806,7 @@ exports[`Storyshots Table Action column 1`] = `
               </th>
               <th
                 className="startAlign unselectable"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -32193,6 +32200,7 @@ exports[`Storyshots Table Disabled orderable 1`] = `
               </th>
               <th
                 className="active orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -32211,6 +32219,7 @@ exports[`Storyshots Table Disabled orderable 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -32229,6 +32238,7 @@ exports[`Storyshots Table Disabled orderable 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -32247,6 +32257,7 @@ exports[`Storyshots Table Disabled orderable 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -32265,6 +32276,7 @@ exports[`Storyshots Table Disabled orderable 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -32283,6 +32295,7 @@ exports[`Storyshots Table Disabled orderable 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33371,6 +33384,7 @@ exports[`Storyshots Table Empty renderer column 1`] = `
             <tr>
               <th
                 className="startAlign active"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -33381,6 +33395,7 @@ exports[`Storyshots Table Empty renderer column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33400,6 +33415,7 @@ exports[`Storyshots Table Empty renderer column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33419,6 +33435,7 @@ exports[`Storyshots Table Empty renderer column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33438,6 +33455,7 @@ exports[`Storyshots Table Empty renderer column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33457,6 +33475,7 @@ exports[`Storyshots Table Empty renderer column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33476,6 +33495,7 @@ exports[`Storyshots Table Empty renderer column 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33775,6 +33795,7 @@ exports[`Storyshots Table Empty table 1`] = `
             <tr>
               <th
                 className="active orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33793,6 +33814,7 @@ exports[`Storyshots Table Empty table 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33811,6 +33833,7 @@ exports[`Storyshots Table Empty table 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33829,6 +33852,7 @@ exports[`Storyshots Table Empty table 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33847,6 +33871,7 @@ exports[`Storyshots Table Empty table 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33865,6 +33890,7 @@ exports[`Storyshots Table Empty table 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33883,6 +33909,7 @@ exports[`Storyshots Table Empty table 1`] = `
               </th>
               <th
                 className="orderable disabled"
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -33947,6 +33974,7 @@ exports[`Storyshots Table Loading rows 1`] = `
           <tr>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -33956,6 +33984,7 @@ exports[`Storyshots Table Loading rows 1`] = `
             </th>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -33965,6 +33994,7 @@ exports[`Storyshots Table Loading rows 1`] = `
             </th>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -33974,6 +34004,7 @@ exports[`Storyshots Table Loading rows 1`] = `
             </th>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -34056,6 +34087,7 @@ exports[`Storyshots Table Loading rows 1`] = `
           <tr>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -34065,6 +34097,7 @@ exports[`Storyshots Table Loading rows 1`] = `
             </th>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -34074,6 +34107,7 @@ exports[`Storyshots Table Loading rows 1`] = `
             </th>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -34083,6 +34117,7 @@ exports[`Storyshots Table Loading rows 1`] = `
             </th>
             <th
               className="startAlign"
+              style={Object {}}
             >
               <div
                 className="startAlign tableHeadItem"
@@ -34231,6 +34266,7 @@ exports[`Storyshots Table Selectable and expandable 1`] = `
               <th
                 className="active orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -34250,6 +34286,7 @@ exports[`Storyshots Table Selectable and expandable 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -34269,6 +34306,7 @@ exports[`Storyshots Table Selectable and expandable 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -34288,6 +34326,7 @@ exports[`Storyshots Table Selectable and expandable 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -34307,6 +34346,7 @@ exports[`Storyshots Table Selectable and expandable 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -34326,6 +34366,7 @@ exports[`Storyshots Table Selectable and expandable 1`] = `
               <th
                 className="orderable"
                 onClick={[Function]}
+                style={Object {}}
               >
                 <div
                   className="tableHeadItem"
@@ -35434,6 +35475,7 @@ exports[`Storyshots Table Simple 1`] = `
             <tr>
               <th
                 className="startAlign"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -35443,6 +35485,7 @@ exports[`Storyshots Table Simple 1`] = `
               </th>
               <th
                 className="startAlign"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -35452,6 +35495,7 @@ exports[`Storyshots Table Simple 1`] = `
               </th>
               <th
                 className="startAlign"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -35461,6 +35505,7 @@ exports[`Storyshots Table Simple 1`] = `
               </th>
               <th
                 className="startAlign"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -35470,6 +35515,7 @@ exports[`Storyshots Table Simple 1`] = `
               </th>
               <th
                 className="startAlign"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -35479,6 +35525,7 @@ exports[`Storyshots Table Simple 1`] = `
               </th>
               <th
                 className="startAlign"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -35488,6 +35535,7 @@ exports[`Storyshots Table Simple 1`] = `
               </th>
               <th
                 className="startAlign"
+                style={Object {}}
               >
                 <div
                   className="startAlign tableHeadItem"
@@ -35805,8 +35853,12 @@ exports[`Storyshots Table Width Control 1`] = `
         >
           <tr>
             <th
-              className="startAlign"
-              width={80}
+              className="startAlign active"
+              style={
+                Object {
+                  "width": "80px",
+                }
+              }
             >
               <div
                 className="startAlign tableHeadItem"
@@ -35816,7 +35868,11 @@ exports[`Storyshots Table Width Control 1`] = `
             </th>
             <th
               className="startAlign"
-              width={200}
+              style={
+                Object {
+                  "width": "200px",
+                }
+              }
             >
               <div
                 className="startAlign tableHeadItem"
@@ -35826,7 +35882,11 @@ exports[`Storyshots Table Width Control 1`] = `
             </th>
             <th
               className="startAlign"
-              width={80}
+              style={
+                Object {
+                  "width": "80px",
+                }
+              }
             >
               <div
                 className="startAlign tableHeadItem"
@@ -35836,7 +35896,11 @@ exports[`Storyshots Table Width Control 1`] = `
             </th>
             <th
               className="startAlign"
-              width={200}
+              style={
+                Object {
+                  "width": "200px",
+                }
+              }
             >
               <div
                 className="startAlign tableHeadItem"
@@ -35846,7 +35910,11 @@ exports[`Storyshots Table Width Control 1`] = `
             </th>
             <th
               className="startAlign"
-              width={80}
+              style={
+                Object {
+                  "width": "80px",
+                }
+              }
             >
               <div
                 className="startAlign tableHeadItem"
@@ -35856,7 +35924,11 @@ exports[`Storyshots Table Width Control 1`] = `
             </th>
             <th
               className="startAlign"
-              width={200}
+              style={
+                Object {
+                  "width": "200px",
+                }
+              }
             >
               <div
                 className="startAlign tableHeadItem"
@@ -35866,7 +35938,11 @@ exports[`Storyshots Table Width Control 1`] = `
             </th>
             <th
               className="startAlign"
-              width={80}
+              style={
+                Object {
+                  "width": "80px",
+                }
+              }
             >
               <div
                 className="startAlign tableHeadItem"

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -36201,7 +36201,7 @@ exports[`Storyshots Table Width Control 1`] = `
       </table>
       <br />
       <div
-        className="segmentedSwitch"
+        className="segmentedSwitch spacing-medium relevance-normal"
       >
         <label
           className="item"

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -35788,6 +35788,389 @@ exports[`Storyshots Table Simple 1`] = `
 </div>
 `;
 
+exports[`Storyshots Table Width Control 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <section
+    className="typography"
+  >
+    
+    <div>
+      <table
+        className="table"
+      >
+        <thead
+          className="tableHead"
+        >
+          <tr>
+            <th
+              className="startAlign"
+              width={80}
+            >
+              <div
+                className="startAlign tableHeadItem"
+              >
+                Status
+              </div>
+            </th>
+            <th
+              className="startAlign"
+              width={200}
+            >
+              <div
+                className="startAlign tableHeadItem"
+              >
+                Transaction ID
+              </div>
+            </th>
+            <th
+              className="startAlign"
+              width={80}
+            >
+              <div
+                className="startAlign tableHeadItem"
+              >
+                Date
+              </div>
+            </th>
+            <th
+              className="startAlign"
+              width={200}
+            >
+              <div
+                className="startAlign tableHeadItem"
+              >
+                Payment Method
+              </div>
+            </th>
+            <th
+              className="startAlign"
+              width={80}
+            >
+              <div
+                className="startAlign tableHeadItem"
+              >
+                Paid Amount
+              </div>
+            </th>
+            <th
+              className="startAlign"
+              width={200}
+            >
+              <div
+                className="startAlign tableHeadItem"
+              >
+                Cost
+              </div>
+            </th>
+            <th
+              className="startAlign"
+              width={80}
+            >
+              <div
+                className="startAlign tableHeadItem"
+              >
+                Amount
+              </div>
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          className="tableBody"
+        >
+          <tr
+            className="even row"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex="0"
+          >
+            <td
+              className="tableItem centerAlign"
+            >
+              <div>
+                <div
+                  className="legend"
+                >
+                  <abbr
+                    className="acronym"
+                    style={
+                      Object {
+                        "background": "#244d85",
+                      }
+                    }
+                    title="Boleto paid with inferior value"
+                  >
+                    BPIV
+                  </abbr>
+                </div>
+              </div>
+            </td>
+            <td
+              className="tableItem startAlign"
+            >
+              2229597000
+            </td>
+            <td
+              className="tableItem centerAlign"
+            >
+              23/09/2017 - 14:15h
+            </td>
+            <td
+              className="tableItem centerAlign"
+            >
+              Boleto
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$999.999.999,00
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$100.000,00
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$999.999.999,00
+            </td>
+          </tr>
+          <tr
+            className="odd row"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex="0"
+          >
+            <td
+              className="tableItem centerAlign"
+            >
+              <div>
+                <div
+                  className="legend"
+                >
+                  <abbr
+                    className="acronym"
+                    style={
+                      Object {
+                        "background": "#57be76",
+                      }
+                    }
+                    title="Pago"
+                  >
+                    P
+                  </abbr>
+                </div>
+              </div>
+            </td>
+            <td
+              className="tableItem startAlign"
+            >
+              2229597001
+            </td>
+            <td
+              className="tableItem centerAlign"
+            >
+              23/09/2017 - 15:15h
+            </td>
+            <td
+              className="tableItem centerAlign"
+            >
+              Credit card
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$100.000,00
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$12.000,00
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$400.000,00
+            </td>
+          </tr>
+          <tr
+            className="even row"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex="0"
+          >
+            <td
+              className="tableItem centerAlign"
+            >
+              <div>
+                <div
+                  className="legend"
+                >
+                  <abbr
+                    className="acronym"
+                    style={
+                      Object {
+                        "background": "#e47735",
+                      }
+                    }
+                    title="Chargeback"
+                  >
+                    CB
+                  </abbr>
+                </div>
+              </div>
+            </td>
+            <td
+              className="tableItem startAlign"
+            >
+              2229597003
+            </td>
+            <td
+              className="tableItem centerAlign"
+            >
+              23/09/2017 - 16:15h
+            </td>
+            <td
+              className="tableItem centerAlign"
+            >
+              Credit card
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$100.000,00
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$13.000,00
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$500.000,00
+            </td>
+          </tr>
+          <tr
+            className="odd row"
+            onClick={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            tabIndex="0"
+          >
+            <td
+              className="tableItem centerAlign"
+            >
+              <div>
+                <div
+                  className="legend"
+                >
+                  <abbr
+                    className="acronym"
+                    style={
+                      Object {
+                        "background": "#951e3c",
+                      }
+                    }
+                    title="Processing"
+                  >
+                    PR
+                  </abbr>
+                </div>
+              </div>
+            </td>
+            <td
+              className="tableItem startAlign"
+            >
+              2229597004
+            </td>
+            <td
+              className="tableItem"
+            >
+              <span
+                className="empty unselectable"
+              />
+            </td>
+            <td
+              className="tableItem"
+            >
+              <span
+                className="empty unselectable"
+              />
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              <span
+                className="empty unselectable"
+              />
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$14.000,00
+            </td>
+            <td
+              className="tableItem endAlign"
+            >
+              R$600.000,00
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <br />
+      <div
+        className="segmentedSwitch"
+      >
+        <label
+          className="item"
+          htmlFor="segmented-switch-shortid-mock-table-test-noSize"
+        >
+          <input
+            checked={false}
+            disabled={false}
+            id="segmented-switch-shortid-mock-table-test-noSize"
+            name="segmented-switch-shortid-mock"
+            onChange={[Function]}
+            type="radio"
+            value="noSize"
+          />
+          <span
+            className="label"
+          >
+            Same size columns
+          </span>
+        </label>
+        <label
+          className="item"
+          htmlFor="segmented-switch-shortid-mock-table-test-sizedColumns"
+        >
+          <input
+            checked={true}
+            disabled={false}
+            id="segmented-switch-shortid-mock-table-test-sizedColumns"
+            name="segmented-switch-shortid-mock"
+            onChange={[Function]}
+            type="radio"
+            value="sizedColumns"
+          />
+          <span
+            className="label"
+          >
+            Columns with different sizes
+          </span>
+        </label>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`Storyshots Tags Default 1`] = `
 <div
   className="storybook-readme-story"


### PR DESCRIPTION
## Context
This PR solves two problems that was happening in recipients table:
- `status` column was too large for a few small information
- overlap in `id` informations when the screen size changes

This PR is part of this Card: https://github.com/pagarme/former-kit/issues/272 . It is possible to see examples of the problem there.

## Screenshots
Screenshots here:  https://github.com/pagarme/former-kit/issues/272

## Deploy Notes
- `git clone` in this repo
- `yarn` to install dependencies
- `yarn link "former-kit-skin-pagarme` to link
- `yarn storybook`

#### note: 
do not forget to change the second column title to _"Id do Recebedor"_  for the condition to work
