### PR TITLE
Fix DateInput presets

### DIFF
--- a/stories/DateInput/index.js
+++ b/stories/DateInput/index.js
@@ -1,15 +1,35 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import moment from 'moment'
 import IconCalendar from 'emblematic-icons/svg/Calendar32.svg'
 
 import Button from '../../src/Button'
-import Section from '../Section'
 import DateInput from '../../src/DateInput'
+import DropDown from '../../src/Dropdown'
+import Section from '../Section'
 
 import presets from './datePresets'
 import style from './style.css'
+
+const presetsOptions = [
+  {
+    name: '7 days',
+    value: 'last-7',
+  },
+  {
+    name: '15 days',
+    value: 'last-15',
+  },
+  {
+    name: '30 days',
+    value: 'last-30',
+  },
+  {
+    name: 'Today',
+    value: 'today',
+  },
+]
 
 class DateInputState extends React.Component {
   constructor (props) {
@@ -17,6 +37,7 @@ class DateInputState extends React.Component {
 
     this.state = {
       dates: props.dates || {},
+      selectedPreset: props.selectedPreset || 'last-7',
       showCalendar: props.showCalendar,
     }
 
@@ -39,38 +60,69 @@ class DateInputState extends React.Component {
 
   render () {
     const {
-      selectedPreset,
+      selectablePresets,
       selectionMode,
       showClearButton,
       showSidebar,
     } = this.props
-    const { dates, showCalendar } = this.state
+    const {
+      dates,
+      selectedPreset,
+      showCalendar,
+    } = this.state
     return (
-      <div className={style.container}>
-        <DateInput
-          dates={dates}
-          icon={<IconCalendar width={16} height={16} />}
-          onConfirm={action('onConfirm')}
-          onChange={action('onChange')}
-          onPresetChange={this.handlePresetChange}
-          presets={presets}
-          selectedPreset={selectedPreset}
-          selectionMode={selectionMode}
-          showCalendar={showCalendar}
-          showSidebar={showSidebar}
-        />
-        { showClearButton && (
-          <Button onClick={this.resetDates}>
-            Reset Dates
-          </Button>
-        )}
-      </div>
+      <Fragment>
+        {
+          selectablePresets
+          && (
+            <Fragment>
+              <h3>Available presets</h3>
+              <p>The presets can be changed by a parent component</p>
+            </Fragment>
+          )
+        }
+        <div className={style.container}>
+          {
+            selectablePresets
+            && (
+              <div className={style.presetSelector}>
+                <DropDown
+                  name="presets"
+                  onChange={event => this.setState({
+                    selectedPreset: event.target.value,
+                  })}
+                  options={presetsOptions}
+                  value={selectedPreset}
+                />
+              </div>
+            )
+          }
+          <DateInput
+            dates={dates}
+            icon={<IconCalendar width={16} height={16} />}
+            onConfirm={action('onConfirm')}
+            onChange={action('onChange')}
+            onPresetChange={this.handlePresetChange}
+            presets={presets}
+            selectedPreset={selectedPreset}
+            selectionMode={selectionMode}
+            showCalendar={showCalendar}
+            showSidebar={showSidebar}
+          />
+          { showClearButton && (
+            <Button onClick={this.resetDates}>
+              Reset Dates
+            </Button>
+          )}
+        </div>
+      </Fragment>
     )
   }
 }
 
 DateInputState.defaultProps = {
   end: null,
+  selectablePresets: null,
   selectedPreset: '',
   start: null,
 }
@@ -122,6 +174,7 @@ storiesOf('DateInput', module)
   .add('with sidebar and selected preset', () => (
     <Section>
       <DateInputState
+        selectablePresets={['last-7', 'last-15', 'last-30', 'today']}
         selectedPreset="last-7"
       />
     </Section>

--- a/stories/DateInput/style.css
+++ b/stories/DateInput/style.css
@@ -9,3 +9,8 @@
 .container > button {
   margin-left: 10px;
 }
+
+.presetSelector {
+  min-width: 95px;
+  margin-right: 16px;
+}

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -11476,14 +11476,41 @@ exports[`Storyshots DateInput with sidebar 1`] = `
                   onKeyDown={[Function]}
                   onKeyPress={[Function]}
                   onPaste={[Function]}
-                  placeholder="Start"
+                  placeholder="09/23/2017"
                   size="8"
-                  value=""
+                  value="09/23/2017"
                 />
                 <span
                   className="expander"
                 >
-                  Start
+                  09/23/2017
+                </span>
+              </div>
+              <div
+                className="separator"
+              />
+              <div
+                className="end"
+              >
+                <input
+                  autoComplete="off"
+                  className="input"
+                  mask="11/11/1111"
+                  maxLength={10}
+                  name="endDate"
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onPaste={[Function]}
+                  placeholder="End"
+                  size="8"
+                  value="09/30/2017"
+                />
+                <span
+                  className="expander"
+                >
+                  09/30/2017
                 </span>
               </div>
             </div>
@@ -11539,14 +11566,41 @@ exports[`Storyshots DateInput with sidebar and clear button 1`] = `
                   onKeyDown={[Function]}
                   onKeyPress={[Function]}
                   onPaste={[Function]}
-                  placeholder="09/15/2017"
+                  placeholder="09/23/2017"
                   size="8"
-                  value="09/15/2017"
+                  value="09/23/2017"
                 />
                 <span
                   className="expander"
                 >
-                  09/15/2017
+                  09/23/2017
+                </span>
+              </div>
+              <div
+                className="separator"
+              />
+              <div
+                className="end"
+              >
+                <input
+                  autoComplete="off"
+                  className="input"
+                  mask="11/11/1111"
+                  maxLength={10}
+                  name="endDate"
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onPaste={[Function]}
+                  placeholder="End"
+                  size="8"
+                  value="09/30/2017"
+                />
+                <span
+                  className="expander"
+                >
+                  09/30/2017
                 </span>
               </div>
             </div>
@@ -11588,7 +11642,68 @@ exports[`Storyshots DateInput with sidebar and selected preset 1`] = `
   >
     
     <div>
+      <h3>
+        Available presets
+      </h3>
+      <p>
+        The presets can be changed by a parent component
+      </p>
       <div>
+        <div>
+          <div
+            className="dropdown"
+          >
+            
+            <select
+              className="select"
+              disabled={false}
+              id="presets-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="last-7"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                
+              </option>
+              <option
+                className="option active"
+                value="last-7"
+              >
+                7 days
+              </option>
+              <option
+                className="option"
+                value="last-15"
+              >
+                15 days
+              </option>
+              <option
+                className="option"
+                value="last-30"
+              >
+                30 days
+              </option>
+              <option
+                className="option"
+                value="today"
+              >
+                Today
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            
+          </div>
+        </div>
         <div
           className="dateselector"
         >
@@ -11713,14 +11828,41 @@ exports[`Storyshots DateInput with sidebar first 1`] = `
                   onKeyDown={[Function]}
                   onKeyPress={[Function]}
                   onPaste={[Function]}
-                  placeholder="Select a preset"
+                  placeholder="09/23/2017"
                   size="8"
-                  value=""
+                  value="09/23/2017"
                 />
                 <span
                   className="expander"
                 >
-                  Select a preset
+                  09/23/2017
+                </span>
+              </div>
+              <div
+                className="separator"
+              />
+              <div
+                className="end"
+              >
+                <input
+                  autoComplete="off"
+                  className="input"
+                  mask="11/11/1111"
+                  maxLength={10}
+                  name="endDate"
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onPaste={[Function]}
+                  placeholder="End"
+                  size="8"
+                  value="09/30/2017"
+                />
+                <span
+                  className="expander"
+                >
+                  09/30/2017
                 </span>
               </div>
             </div>
@@ -11776,14 +11918,14 @@ exports[`Storyshots DateInput without sidebar and period selection 1`] = `
                   onKeyDown={[Function]}
                   onKeyPress={[Function]}
                   onPaste={[Function]}
-                  placeholder="Start"
+                  placeholder="09/23/2017"
                   size="8"
-                  value=""
+                  value="09/23/2017"
                 />
                 <span
                   className="expander"
                 >
-                  Start
+                  09/23/2017
                 </span>
               </div>
               <div
@@ -11805,12 +11947,12 @@ exports[`Storyshots DateInput without sidebar and period selection 1`] = `
                   onPaste={[Function]}
                   placeholder="End"
                   size="8"
-                  value=""
+                  value="09/30/2017"
                 />
                 <span
                   className="expander"
                 >
-                  End
+                  09/30/2017
                 </span>
               </div>
             </div>
@@ -11866,7 +12008,34 @@ exports[`Storyshots DateInput without sidebar and pre selected date 1`] = `
                   onKeyDown={[Function]}
                   onKeyPress={[Function]}
                   onPaste={[Function]}
-                  placeholder="09/30/2017"
+                  placeholder="09/23/2017"
+                  size="8"
+                  value="09/23/2017"
+                />
+                <span
+                  className="expander"
+                >
+                  09/23/2017
+                </span>
+              </div>
+              <div
+                className="separator"
+              />
+              <div
+                className="end"
+              >
+                <input
+                  autoComplete="off"
+                  className="input"
+                  mask="11/11/1111"
+                  maxLength={10}
+                  name="endDate"
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onPaste={[Function]}
+                  placeholder="End"
                   size="8"
                   value="09/30/2017"
                 />
@@ -11929,14 +12098,14 @@ exports[`Storyshots DateInput without sidebar and pre selected period 1`] = `
                   onKeyDown={[Function]}
                   onKeyPress={[Function]}
                   onPaste={[Function]}
-                  placeholder="09/26/2017"
+                  placeholder="09/23/2017"
                   size="8"
-                  value="09/26/2017"
+                  value="09/23/2017"
                 />
                 <span
                   className="expander"
                 >
-                  09/26/2017
+                  09/23/2017
                 </span>
               </div>
               <div
@@ -12019,14 +12188,41 @@ exports[`Storyshots DateInput without sidebar and single selection 1`] = `
                   onKeyDown={[Function]}
                   onKeyPress={[Function]}
                   onPaste={[Function]}
-                  placeholder="Start"
+                  placeholder="09/23/2017"
                   size="8"
-                  value=""
+                  value="09/23/2017"
                 />
                 <span
                   className="expander"
                 >
-                  Start
+                  09/23/2017
+                </span>
+              </div>
+              <div
+                className="separator"
+              />
+              <div
+                className="end"
+              >
+                <input
+                  autoComplete="off"
+                  className="input"
+                  mask="11/11/1111"
+                  maxLength={10}
+                  name="endDate"
+                  onChange={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onPaste={[Function]}
+                  placeholder="End"
+                  size="8"
+                  value="09/30/2017"
+                />
+                <span
+                  className="expander"
+                >
+                  09/30/2017
                 </span>
               </div>
             </div>


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->

## Context
<!-- What problem are you trying to solve? -->
When presets were received by props in the `DateInput` component the `componentDidMount` wasn't changing the component state.
## Checklist
- [ ] When the presets received by props changes the component must be updated
<!-- Describe the main changes that your PR does. -->

## Linked Issues
- [ ] Resolves #271
<!-- Add the respective issues linked to this PR -->

## How to test
1 - Clone this project and install its dependencies
```
git clone  git@github.com:pagarme/former-kit.git
```
2 - Get the remotes updates
```
cd former-kit
git fetch --all
```
3 - Move to this branch
```
git checkout fix/date-input-presets
```
4 - install the dependencies
```
yarn
```
5 - Run the Storybook
```
  yarn storybook
```
6 - look for the `with sidebar and selected preset` story, it must be changing the `DateInput`correctly when the preset is changed in the `DropDown`, like in the following example:
![DateInput presets example](https://user-images.githubusercontent.com/1773766/59952338-2fb30000-9452-11e9-9607-4c329c3d9bd0.gif)

