### PR TITLE
Fix DateInput presets

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -136,7 +136,7 @@ class DateInput extends React.Component {
       },
       dates,
       presets,
-      selectedPreset,
+      selectedPreset: propsSelectedPreset,
     } = this.props
 
     const {
@@ -151,17 +151,17 @@ class DateInput extends React.Component {
     const isSameEnd = receivedEnd && receivedEnd.isSame(currentEnd, 'day')
 
     if (!equals(prevProps, this.props) && (!isSameStart || !isSameEnd)) {
-      let presetDates
+      const prevPropsSelectedPreset = prevProps.selectedPreset
+      const selectedPreset = prevPropsSelectedPreset !== propsSelectedPreset
+        ? propsSelectedPreset
+        : currentSelectedPreset
+
       const preset = findPreset(selectedPreset, presets)
-      if (selectedPreset !== currentSelectedPreset) {
-        presetDates = getDatesFromPreset(preset)
-      }
+      const presetDates = getDatesFromPreset(preset)
 
       this.setState({ // eslint-disable-line react/no-did-update-set-state
         dates: momentToText(presetDates || dates),
-        selectedPreset: prevProps.selectedPreset !== selectedPreset
-          ? selectedPreset
-          : currentSelectedPreset,
+        selectedPreset,
         selectionMode: preset.mode,
       })
     }


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->

## Context
<!-- What problem are you trying to solve? -->
When presets were received by props in the `DateInput` component the `componentDidMount` wasn't changing the component state.
## Checklist
- [ ] When the presets received by props changes the component must be updated
<!-- Describe the main changes that your PR does. -->

## Linked Issues
- [ ] Resolves #271
<!-- Add the respective issues linked to this PR -->

## How to test
1 - Clone this project and install its dependencies
```
git clone  git@github.com:pagarme/former-kit.git
```
2 - Get the remotes updates
```
cd former-kit
git fetch --all
```
3 - Move to this branch
```
git checkout fix/date-input-presets
```
4 - install the dependencies
```
yarn
```
5 - Run the Storybook
```
  yarn storybook
```
6 - look for the `with sidebar and selected preset` story, it must be changing the `DateInput`correctly when the preset is changed in the `DropDown`, like in the following example:
![DateInput presets example](https://user-images.githubusercontent.com/1773766/59952338-2fb30000-9452-11e9-9607-4c329c3d9bd0.gif)

