### PR TITLE
Remove react memo from Truncate

### DIFF
--- a/src/Truncate/index.js
+++ b/src/Truncate/index.js
@@ -261,4 +261,4 @@ Truncate.defaultProps = {
   tooltipPlacement: 'bottomCenter',
 }
 
-export default consumeTheme(React.memo(Truncate))
+export default consumeTheme(Truncate)


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->
This PR removes the `React.memo` a function which was doing a wrong cache for the component props.

## Context
<!-- What problem are you trying to solve? -->
In a few cases, in Pilot, the truncate wasn't working correctly.

## Checklist
- [ ] Verify truncate in Pilot transactions page.
<!-- Describe the main changes that your PR does. -->

## Linked Issues
- [ ] Resolves https://github.com/pagarme/pilot/issues/1267
<!-- Add the respective issues linked to this PR -->