### PR TITLE
DateInput - Refactor selectedPreset usage

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -162,7 +162,7 @@ class DateInput extends React.Component {
       this.setState({ // eslint-disable-line react/no-did-update-set-state
         dates: momentToText(presetDates || dates),
         selectedPreset,
-        selectionMode: preset.mode,
+        selectionMode: preset && preset.mode,
       })
     }
   }


### PR DESCRIPTION
## Context
This Pull Request solves a problem with the optional usage of the `selectedPreset` prop, which should not cause a problem if not informed.

## Checklist
- [x] Adds preset validation before checking it's properties

## Linked Issues
- [x] Resolves #277
