### PR TITLE
SegmentedSwitch - Add props for relevance and spacing

### DIFF
--- a/src/SegmentedSwitch/SegmentedSwitch.js
+++ b/src/SegmentedSwitch/SegmentedSwitch.js
@@ -45,6 +45,7 @@ class SegmentedSwitch extends PureComponent {
     const {
       disabled,
       options,
+      relevance,
       spacing,
       theme,
     } = this.props
@@ -52,6 +53,7 @@ class SegmentedSwitch extends PureComponent {
     const containerClass = classnames(
       theme.segmentedSwitch,
       theme[`spacing-${spacing}`],
+      theme[`relevance-${relevance}`],
       {
         [theme.disabled]: disabled,
       }
@@ -87,6 +89,12 @@ SegmentedSwitch.propTypes = {
     title: PropTypes.node,
     value: PropTypes.string,
   })).isRequired,
+  /**
+   * The relevance to be used on the buttons
+   */
+  relevance: PropTypes.oneOf([
+    'normal', 'low',
+  ]),
   /**
    * The spacing to be used between the buttons
    */

--- a/src/SegmentedSwitch/SegmentedSwitch.js
+++ b/src/SegmentedSwitch/SegmentedSwitch.js
@@ -45,12 +45,17 @@ class SegmentedSwitch extends PureComponent {
     const {
       disabled,
       options,
+      spacing,
       theme,
     } = this.props
 
-    const containerClass = classnames(theme.segmentedSwitch, {
-      [theme.disabled]: disabled,
-    })
+    const containerClass = classnames(
+      theme.segmentedSwitch,
+      theme[`spacing-${spacing}`],
+      {
+        [theme.disabled]: disabled,
+      }
+    )
 
     return (
       <div className={containerClass}>
@@ -83,6 +88,12 @@ SegmentedSwitch.propTypes = {
     value: PropTypes.string,
   })).isRequired,
   /**
+   * The spacing to be used between the buttons
+   */
+  spacing: PropTypes.oneOf([
+    'tiny', 'small', 'medium', 'large',
+  ]),
+  /**
    * @see [ThemeProvider](#themeprovider) - Theme received from `consumeTheme` wrapper.
    */
   theme: PropTypes.shape({
@@ -107,6 +118,8 @@ SegmentedSwitch.propTypes = {
 
 SegmentedSwitch.defaultProps = {
   disabled: false,
+  relevance: 'normal',
+  spacing: 'medium',
   theme: {},
 }
 

--- a/stories/SpacedSegmentedSwitch/index.js
+++ b/stories/SpacedSegmentedSwitch/index.js
@@ -33,6 +33,8 @@ class SpacedSegmentedSwitchState extends React.Component {
       disabled,
       name,
       options,
+      relevance,
+      spacing,
     } = this.props
     const { value } = this.state
     return (
@@ -41,6 +43,8 @@ class SpacedSegmentedSwitchState extends React.Component {
         name={name}
         onChange={this.handleChange}
         options={options}
+        relevance={relevance}
+        spacing={spacing}
         value={value}
       />
     )
@@ -67,11 +71,37 @@ storiesOf('SpacedSegmentedSwitch', module)
               value: 'from50to100',
             },
             {
-              title: 'More than R$100',
+              title: 'More than $100',
               value: 'moreThan100',
             },
           ]}
           value="from25to100"
+        />
+      </Section>
+      <Section title="With low relevance and tiny spacing">
+        <SpacedSegmentedSwitchState
+          name="table-chart"
+          options={[
+            {
+              title: 'From $0 to $25',
+              value: 'from0to25',
+            },
+            {
+              title: 'From $25 to $50',
+              value: 'from25to100',
+            },
+            {
+              title: 'From $50 to $100',
+              value: 'from50to100',
+            },
+            {
+              title: 'More than $100',
+              value: 'moreThan100',
+            },
+          ]}
+          relevance="low"
+          spacing="tiny"
+          value="table"
         />
       </Section>
       <Section title="With icons">
@@ -91,6 +121,27 @@ storiesOf('SpacedSegmentedSwitch', module)
               value: 'lock',
             },
           ]}
+          value="table"
+        />
+      </Section>
+      <Section title="With icons and low relevance">
+        <SpacedSegmentedSwitchState
+          name="table-chart"
+          options={[
+            {
+              title: <IconTable width={16} height={16} />,
+              value: 'table',
+            },
+            {
+              title: <IconChart width={16} height={16} />,
+              value: 'chart',
+            },
+            {
+              title: <IconLock width={16} height={16} />,
+              value: 'lock',
+            },
+          ]}
+          relevance="low"
           value="table"
         />
       </Section>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -29517,7 +29517,7 @@ exports[`Storyshots SegmentedSwitch Default 1`] = `
       </h2>
       <div>
         <div
-          className="segmentedSwitch"
+          className="segmentedSwitch spacing-medium relevance-normal"
         >
           <label
             className="item"
@@ -29568,7 +29568,7 @@ exports[`Storyshots SegmentedSwitch Default 1`] = `
       </h2>
       <div>
         <div
-          className="segmentedSwitch"
+          className="segmentedSwitch spacing-medium relevance-normal"
         >
           <label
             className="item"
@@ -29657,7 +29657,7 @@ exports[`Storyshots SegmentedSwitch Default 1`] = `
       </h2>
       <div>
         <div
-          className="segmentedSwitch"
+          className="segmentedSwitch spacing-medium relevance-normal"
         >
           <label
             className="item"
@@ -29714,7 +29714,7 @@ exports[`Storyshots SegmentedSwitch Default 1`] = `
       </h2>
       <div>
         <div
-          className="segmentedSwitch disabled"
+          className="segmentedSwitch spacing-medium relevance-normal disabled"
         >
           <label
             className="item"
@@ -30284,7 +30284,7 @@ exports[`Storyshots SpacedSegmentedSwitch Default 1`] = `
       </h2>
       <div>
         <div
-          className="segmentedSwitch"
+          className="segmentedSwitch spacing-medium relevance-normal"
         >
           <label
             className="item"
@@ -30359,7 +30359,96 @@ exports[`Storyshots SpacedSegmentedSwitch Default 1`] = `
             <span
               className="label"
             >
-              More than R$100
+              More than $100
+            </span>
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        With low relevance and tiny spacing
+      </h2>
+      <div>
+        <div
+          className="segmentedSwitch spacing-tiny relevance-low"
+        >
+          <label
+            className="item"
+            htmlFor="segmented-switch-shortid-mock-table-chart-from0to25"
+          >
+            <input
+              checked={false}
+              disabled={false}
+              id="segmented-switch-shortid-mock-table-chart-from0to25"
+              name="segmented-switch-shortid-mock"
+              onChange={[Function]}
+              type="radio"
+              value="from0to25"
+            />
+            <span
+              className="label"
+            >
+              From $0 to $25
+            </span>
+          </label>
+          <label
+            className="item"
+            htmlFor="segmented-switch-shortid-mock-table-chart-from25to100"
+          >
+            <input
+              checked={false}
+              disabled={false}
+              id="segmented-switch-shortid-mock-table-chart-from25to100"
+              name="segmented-switch-shortid-mock"
+              onChange={[Function]}
+              type="radio"
+              value="from25to100"
+            />
+            <span
+              className="label"
+            >
+              From $25 to $50
+            </span>
+          </label>
+          <label
+            className="item"
+            htmlFor="segmented-switch-shortid-mock-table-chart-from50to100"
+          >
+            <input
+              checked={false}
+              disabled={false}
+              id="segmented-switch-shortid-mock-table-chart-from50to100"
+              name="segmented-switch-shortid-mock"
+              onChange={[Function]}
+              type="radio"
+              value="from50to100"
+            />
+            <span
+              className="label"
+            >
+              From $50 to $100
+            </span>
+          </label>
+          <label
+            className="item"
+            htmlFor="segmented-switch-shortid-mock-table-chart-moreThan100"
+          >
+            <input
+              checked={false}
+              disabled={false}
+              id="segmented-switch-shortid-mock-table-chart-moreThan100"
+              name="segmented-switch-shortid-mock"
+              onChange={[Function]}
+              type="radio"
+              value="moreThan100"
+            />
+            <span
+              className="label"
+            >
+              More than $100
             </span>
           </label>
         </div>
@@ -30373,7 +30462,86 @@ exports[`Storyshots SpacedSegmentedSwitch Default 1`] = `
       </h2>
       <div>
         <div
-          className="segmentedSwitch"
+          className="segmentedSwitch spacing-medium relevance-normal"
+        >
+          <label
+            className="item"
+            htmlFor="segmented-switch-shortid-mock-table-chart-table"
+          >
+            <input
+              checked={true}
+              disabled={false}
+              id="segmented-switch-shortid-mock-table-chart-table"
+              name="segmented-switch-shortid-mock"
+              onChange={[Function]}
+              type="radio"
+              value="table"
+            />
+            <span
+              className="label"
+            >
+              <Menu32.svg
+                height={16}
+                width={16}
+              />
+            </span>
+          </label>
+          <label
+            className="item"
+            htmlFor="segmented-switch-shortid-mock-table-chart-chart"
+          >
+            <input
+              checked={false}
+              disabled={false}
+              id="segmented-switch-shortid-mock-table-chart-chart"
+              name="segmented-switch-shortid-mock"
+              onChange={[Function]}
+              type="radio"
+              value="chart"
+            />
+            <span
+              className="label"
+            >
+              <TrendingUp32.svg
+                height={16}
+                width={16}
+              />
+            </span>
+          </label>
+          <label
+            className="item"
+            htmlFor="segmented-switch-shortid-mock-table-chart-lock"
+          >
+            <input
+              checked={false}
+              disabled={false}
+              id="segmented-switch-shortid-mock-table-chart-lock"
+              name="segmented-switch-shortid-mock"
+              onChange={[Function]}
+              type="radio"
+              value="lock"
+            />
+            <span
+              className="label"
+            >
+              <Lock32.svg
+                height={16}
+                width={16}
+              />
+            </span>
+          </label>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        With icons and low relevance
+      </h2>
+      <div>
+        <div
+          className="segmentedSwitch spacing-medium relevance-low"
         >
           <label
             className="item"
@@ -30452,7 +30620,7 @@ exports[`Storyshots SpacedSegmentedSwitch Default 1`] = `
       </h2>
       <div>
         <div
-          className="segmentedSwitch disabled"
+          className="segmentedSwitch spacing-medium relevance-normal disabled"
         >
           <label
             className="item"


### PR DESCRIPTION
## Context
We need to implement a `relevance` prop for `SpacedSegmentedSwitch` which will be used as a period selection on Pilot's home.

## Checklist
- [x] Must have a prop `relevance` with `normal` and `low` as possible values
- [x] Must have a prop `spacing` with `normal` and `tiny` as possible values

## Linked Issues
- [x] Resolves #279

## Screenshots

### Preview:
![image](https://user-images.githubusercontent.com/18339615/60989683-f7019a80-a31c-11e9-8763-e543cb21ef98.png)

## How to test
1. Link with `former-kit-skin-pagarme/add/low-relevance-segmentedswitch`
2. Run storybook
