### PR TITLE
Release 1.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "emblematic-icons": "0.6.1",
-    "former-kit-skin-pagarme": "1.3.2",
+    "former-kit-skin-pagarme": "1.3.3",
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6321,10 +6321,10 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-former-kit-skin-pagarme@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.3.2.tgz#cc6711f40dff84c0c0e1ecfc902fe680dc0295c1"
-  integrity sha512-PLONRUhYHhmaIWYgVYlZWf2ZTSWurdgxv34CqvZB9hgTkh8oVn02azWG4SNS1mdqLNuzq6BLJD5FHsdO7w8t+g==
+former-kit-skin-pagarme@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.3.3.tgz#bb78e16e58df1a7b60825f3abd9799d667e2ef14"
+  integrity sha512-iDIwihhcABVCL4pq6punonPCwV7vK1Qdc1cDnUqcULKYvpHotIqq4htft+LkXjY+4v8V6FYcuvpWRcL8Gys4vw==
   dependencies:
     emblematic-icons "0.6.1"
     react-dates "18.4.0"


### PR DESCRIPTION
### This relase includes:
- add property size to Modal component
- fix DateInput presets usage
- remove react memo from Truncate component
- update dependecy `former-kit-skin-pagarme` to `1.3.3`

### Merged pull requests:
- Add a new props to Modal component: size #270
- Fix DateInput presets #274
- Fix DateInput presets #275
- Remove react memo from Truncate #276
- DateInput - Refactor selectedPreset usage #278

resolves #281 