### PR TITLE
DateSelector - add placement prop

### DIFF
--- a/src/DateSelector/index.js
+++ b/src/DateSelector/index.js
@@ -279,6 +279,7 @@ class DateSelector extends Component {
   render () {
     const {
       children,
+      placement,
       presets,
       selectedPreset,
       showCalendar,
@@ -311,6 +312,7 @@ class DateSelector extends Component {
           )}
           onClick={() => null}
           onClickOutside={this.handlePopoverClose}
+          placement={placement}
           visible={visible}
         >
           {children}
@@ -370,6 +372,14 @@ DateSelector.propTypes = {
    * Triggered when a preset is selected.
    */
   onPresetChange: func,
+  /**
+   * @see [Popover](#popover) - The placement to be used on Popover component.
+   * This will change the calendar's position to open from the left or right
+   * corner of the child component.
+   */
+  placement: oneOf([
+    'bottomEnd', 'bottomStart',
+  ]),
   /**
    * Props structure which is used to create the left side menu, this menu allows
    * the user to select dates in preset dates, ranges, etc.
@@ -454,6 +464,7 @@ DateSelector.defaultProps = {
   icons: {},
   isValidDay: null,
   onPresetChange: () => undefined,
+  placement: 'bottomStart',
   presets: [],
   selectedPreset: '',
   selectionMode: 'single',

--- a/stories/DateSelector/index.js
+++ b/stories/DateSelector/index.js
@@ -1,12 +1,14 @@
-import React from 'react'
+import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
 import moment from 'moment'
 
 import Button from '../../src/Button'
-import Section from '../Section'
+import Flexbox from '../../src/Flexbox'
+import Spacing from '../../src/Spacing'
 import DateSelector from '../../src/DateSelector'
+import Section from '../Section'
 import AsideState from './aside'
 
 import presets from './presets'
@@ -50,14 +52,26 @@ class DateSelectorExample extends React.Component {
   }
 
   render () {
-    const { dateSelectorVisible, dates, selectedPreset } = this.state
-    const { selectionMode, showCalendar, showSidebar } = this.props
+    const {
+      dateSelectorVisible,
+      dates,
+      selectedPreset,
+    } = this.state
+
+    const {
+      placement,
+      selectionMode,
+      showCalendar,
+      showSidebar,
+    } = this.props
+
     return (
       <DateSelector
         dates={dates}
         onConfirm={newDates => action('onConfirm')(newDates)}
         onChange={this.handleDatesChange}
         onPresetChange={this.handlePresetChange}
+        placement={placement}
         presets={presets}
         selectedPreset={selectedPreset}
         selectionMode={selectionMode}
@@ -95,6 +109,24 @@ storiesOf('DateSelector', module)
         showSidebar={false}
       />
     </Section>
+  ))
+  .add('With alternate placement', () => (
+    <Fragment>
+      <Section title="default">
+        <DateSelectorExample
+          showSidebar={false}
+        />
+      </Section>
+      <Section title="bottomEnd">
+        <Flexbox justifyContent="flex-end">
+          <DateSelectorExample
+            placement="bottomEnd"
+            showSidebar={false}
+          />
+          <Spacing size="tiny" />
+        </Flexbox>
+      </Section>
+    </Fragment>
   ))
   .add('Without sidebar and pre selected date', () => (
     <Section>

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -12598,6 +12598,100 @@ exports[`Storyshots DateSelector Aside with initial selected preset 1`] = `
 </div>
 `;
 
+exports[`Storyshots DateSelector With alternate placement 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <section
+    className=""
+  >
+    <h2>
+      default
+    </h2>
+    <div>
+      <div
+        className="dateselector"
+      >
+        <div
+          className="target"
+          onClick={[Function]}
+          role="presentation"
+        >
+          <button
+            className="button flat normalRelevance default"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Button
+            </span>
+            <span
+              className="ripple"
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </section>
+  <section
+    className=""
+  >
+    <h2>
+      bottomEnd
+    </h2>
+    <div>
+      <div
+        className="flexbox alignFlexStart justifyFlexEnd row"
+      >
+        <div
+          className="dateselector"
+        >
+          <div
+            className="target"
+            onClick={[Function]}
+            role="presentation"
+          >
+            <button
+              className="button flat normalRelevance default"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span>
+                Button
+              </span>
+              <span
+                className="ripple"
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0,
+                  }
+                }
+              />
+            </button>
+          </div>
+        </div>
+        <div
+          className="spacing tiny"
+        />
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`Storyshots DateSelector With sidebar 1`] = `
 <div
   className="storybook-readme-story"


### PR DESCRIPTION
## Context
In order to accomplish our design necessities, we need to be able to control the DateSelector's `placement` prop. This pull request adds it to the component.

## Checklist
- [x] `DateSelector` pass down to `Popover` the `placement` prop

## Linked Issues
- [x] Resolves #287

## Screenshots

### Preview:
![image](https://user-images.githubusercontent.com/18339615/62164846-87674580-b2f3-11e9-9f7a-638b03acbe9c.png)
