### PR TITLE
Date Input: Fix momentToText validation

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -129,6 +129,7 @@ class DateInput extends React.Component {
 
   componentDidUpdate (prevProps) {
     const {
+      dates,
       dates: {
         end: receivedEnd,
         start: receivedStart,
@@ -154,7 +155,7 @@ class DateInput extends React.Component {
       const presetDates = getDatesFromPreset(preset)
 
       this.setState({ // eslint-disable-line react/no-did-update-set-state
-        dates: momentToText(presetDates),
+        dates: momentToText(presetDates || dates),
         selectedPreset: propsSelectedPreset,
         selectionMode: preset && preset.mode,
       })


### PR DESCRIPTION
## Context
If we filter for a period of days in a row on the Extract page, an error is caused in `dateHelpers`, displaying the modal failure of the application. This PRs fixes `momentToText` validation. 

## Checklist
- [x] Add `dates` to props and add dates to momentToText validation. 

## Linked Issues
- [ ] Resolves https://github.com/pagarme/pilot/issues/1302