### PR TITLE
sidebar-link: add prop beginExpanded

### DIFF
--- a/src/Sidebar/SidebarLink.js
+++ b/src/Sidebar/SidebarLink.js
@@ -19,11 +19,13 @@ const Arrow = ({ active, icons }) => {
 }
 
 class SidebarLink extends React.Component {
-  constructor () {
-    super()
+  constructor (props) {
+    super(props)
+
+    const { beginExpanded } = this.props
 
     this.state = {
-      collapsed: true,
+      collapsed: !beginExpanded,
       focused: false,
     }
 
@@ -160,6 +162,10 @@ SidebarLink.propTypes = {
    */
   active: PropTypes.bool,
   /**
+   * Indicates if the children should starts collapsed or not.
+   */
+  beginExpanded: PropTypes.bool,
+  /**
    * The children can contain any kind of component.
    */
   children: PropTypes.node,
@@ -238,6 +244,7 @@ SidebarLink.propTypes = {
 
 SidebarLink.defaultProps = {
   active: false,
+  beginExpanded: false,
   children: null,
   collapsed: false,
   icon: null,


### PR DESCRIPTION
## Context
Sometimes makes sense to add a menu on sidebar that needs to start opened, to be more noticeable by the user and easy to use.

So this PR add a new prop to be able to customise it: `childrenBeginOpen`
