### PR TITLE
placement: improve prop-types

### DIFF
--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -131,7 +131,20 @@ Popover.propTypes = {
   /**
    * The popover position when it's visible
    */
-  placement: PropTypes.string,
+  placement: PropTypes.oneOf([
+    'rightStart',
+    'rightMiddle',
+    'rightEnd',
+    'topStart',
+    'bottomStart',
+    'bottomCenter',
+    'bottomEnd',
+    'topCenter',
+    'leftStart',
+    'leftMiddle',
+    'leftEnd',
+    'topEnd',
+  ]),
   /**
     * @see [ThemeProvider](#themeprovider) - Theme received from `consumeTheme` wrapper.
     */

--- a/src/Tooltip/index.js
+++ b/src/Tooltip/index.js
@@ -129,7 +129,20 @@ Tooltip.propTypes = {
   /**
    * The position you want to render the tooltip when it's visible.
    */
-  placement: PropTypes.string,
+  placement: PropTypes.oneOf([
+    'rightStart',
+    'rightMiddle',
+    'rightEnd',
+    'topStart',
+    'bottomStart',
+    'bottomCenter',
+    'bottomEnd',
+    'topCenter',
+    'leftStart',
+    'leftMiddle',
+    'leftEnd',
+    'topEnd',
+  ]),
   /**
    * @see [ThemeProvider](#themeprovider) - Theme received from `consumeTheme` wrapper.
    */


### PR DESCRIPTION
## Context
Improve `prop-types` restricting the amount of values accepted by `placement` on `Tooltip` and `Popover` components.