### PR TITLE
sidebar-content: fix its export

### DIFF
--- a/src/Sidebar/SidebarContent.js
+++ b/src/Sidebar/SidebarContent.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import classNames from 'classnames'
 import ThemeConsumer from '../ThemeConsumer'
 
 const consumeTheme = ThemeConsumer('UISidebar')
 
-const SidebarContent = ({ children, theme }) => (
-  <div className={theme.content}>
+const SidebarContent = ({ children, className, theme }) => (
+  <div className={classNames(theme.content, className)}>
     {children}
   </div>
 )
@@ -15,6 +16,10 @@ SidebarContent.propTypes = {
    * The children can contain any kind of component.
    */
   children: PropTypes.node.isRequired,
+  /**
+   * Custom CSS class.
+   */
+  className: PropTypes.string,
   /**
    * The style classes for this element.
    */
@@ -27,6 +32,7 @@ SidebarContent.propTypes = {
 }
 
 SidebarContent.defaultProps = {
+  className: null,
   theme: {},
 }
 

--- a/src/Sidebar/index.js
+++ b/src/Sidebar/index.js
@@ -1,4 +1,5 @@
 export { default as Sidebar } from './Sidebar'
+export { default as SidebarContent } from './SidebarContent'
 export { default as SidebarHeader } from './SidebarHeader'
 export { default as SidebarLinks } from './SidebarLinks'
 export { default as SidebarLink } from './SidebarLink'


### PR DESCRIPTION
## Context
The component `SidebarContent` is documented and is necessary on some situations - but it isn't exported.
This PR fixes it exporting it in order to be able to use on others projects.
