### PR TITLE
truncate fix text update

### DIFF
--- a/src/Truncate/index.js
+++ b/src/Truncate/index.js
@@ -116,10 +116,10 @@ const Truncate = ({
     }
   }, [fitText, parentRef, wrapperRef])
 
-  const emptyStateEffect = () => {
+  const inlineEffect = () => {
     const wrapper = prop('current', wrapperRef)
 
-    if (wrapper && !wrapper.innerText) {
+    if (wrapper && (!wrapper.innerText || prevText !== text)) {
       const parent = prop('parentElement', wrapper)
       if (parent) {
         const parentStyle = window.getComputedStyle(parent)
@@ -153,7 +153,10 @@ const Truncate = ({
     }
   }
 
-  useEffect(emptyStateEffect, [multiline, parentRef, text, wrapperRef])
+  useEffect(
+    inlineEffect,
+    [multiline, parentRef, prevText, text, wrapperRef]
+  )
   useEffect(() => {
     const wrapper = prop('current', wrapperRef)
     if (multiline) {


### PR DESCRIPTION
## Context
In some cases when property text is update the text rendered by the component is no updated.
This pull request change the validation inside the useEffect to always update the `currentText` state when the property text changes

## how to test
- checkout branch `fix/truncate-update`
- create a link `yarn link`
- install dependencies `yarn start`
- build the package `yarn build`
- go to the pilot repo directory
- checkout branch `release/v0.21.0`
- link with `former-kit` `yarn link former-kit`
- start pilot `yarn start`
- navigate to the transactions list page
- filter the transacions by a issue that is not the in the first row
- the column `Nome` needs to update the value displayed

## Linked Issues
- Inconsistência no nome do cliente na listagem de transações https://github.com/pagarme/pilot/issues/1445