### PR TITLE
Dateinput - Updates focus usability

### DIFF
--- a/src/DateInput/index.js
+++ b/src/DateInput/index.js
@@ -118,12 +118,12 @@ class DateInput extends React.Component {
     }
 
     this.name = shortid.generate()
-    this.getNextInput = this.getNextInput.bind(this)
     this.handleConfirm = this.handleConfirm.bind(this)
     this.handleDatesChange = this.handleDatesChange.bind(this)
     this.handleStartInputChange = this.handleInputChange.bind(this, 'start')
     this.handleEndInputChange = this.handleInputChange.bind(this, 'end')
     this.handleInputFocus = this.handleInputFocus.bind(this)
+    this.handleFocusChange = this.handleFocusChange.bind(this)
     this.handlePresetChange = this.handlePresetChange.bind(this)
   }
 
@@ -162,15 +162,6 @@ class DateInput extends React.Component {
     }
   }
 
-  getNextInput () {
-    const {
-      dates,
-    } = this.state
-
-    const nextInputToFocus = dates.start ? 'endDate' : 'startDate'
-    return nextInputToFocus
-  }
-
   handleConfirm (value) {
     const {
       limits,
@@ -197,16 +188,9 @@ class DateInput extends React.Component {
   }
 
   handleDatesChange (dates) {
-    const {
-      focusedInput,
-      selectionMode,
-    } = this.state
     const { onChange } = this.props
     this.setState({
       dates: momentToText(dates),
-      focusedInput: selectionMode === 'period' && focusedInput === 'startDate'
-        ? 'endDate'
-        : 'startDate',
     })
 
     onChange(dates)
@@ -252,6 +236,12 @@ class DateInput extends React.Component {
         showPopover: true,
       })
     }
+  }
+
+  handleFocusChange (focusedInput) {
+    this.setState({
+      focusedInput,
+    })
   }
 
   handlePresetChange (dates, preset) {
@@ -388,6 +378,7 @@ class DateInput extends React.Component {
         isValidDay={isValidDay}
         onConfirm={this.handleConfirm}
         onChange={this.handleDatesChange}
+        onFocusChange={this.handleFocusChange}
         onPresetChange={this.handlePresetChange}
         presets={presets}
         selectedPreset={selectedPreset}

--- a/src/DateSelector/index.js
+++ b/src/DateSelector/index.js
@@ -216,6 +216,7 @@ class DateSelector extends Component {
       focusedInput,
       icons,
       isValidDay,
+      onFocusChange,
       presets,
       selectedPreset,
       selectionMode,
@@ -247,6 +248,7 @@ class DateSelector extends Component {
           dateSelection={dateSelectionMode}
           focusedInput={focusedInput}
           onChange={this.handleOnChange}
+          onFocusChange={onFocusChange}
         />
       </div>
     )
@@ -368,6 +370,10 @@ DateSelector.propTypes = {
    * Triggered when popover closes.
    */
   onConfirm: func.isRequired,
+  /*
+   * Triggered when a day is selected on Calendar
+   */
+  onFocusChange: func,
   /**
    * Triggered when a preset is selected.
    */
@@ -463,7 +469,8 @@ DateSelector.defaultProps = {
   focusedInput: null,
   icons: {},
   isValidDay: null,
-  onPresetChange: () => undefined,
+  onFocusChange: identity,
+  onPresetChange: identity,
   placement: 'bottomStart',
   presets: [],
   selectedPreset: '',


### PR DESCRIPTION
## Context
We need to make our DateInput more user friendly, and our input focus handling is an important step towards that. This Pull Request intends to not change it when selecting presets from DateInput's sidebar.

## Checklist
- [x] Input focus does not change when selecting date presets from DateInput's sidebar.

## How to test
- Click on a date preset and the input selection should be kept on the start date

## Linked Issues
- [x] Resolves https://github.com/pagarme/pilot/issues/1333