### PR TITLE
segmented-switch: add classname prop

### DIFF
--- a/src/SegmentedSwitch/SegmentedSwitch.js
+++ b/src/SegmentedSwitch/SegmentedSwitch.js
@@ -43,6 +43,7 @@ class SegmentedSwitch extends PureComponent {
 
   render () {
     const {
+      className,
       disabled,
       options,
       relevance,
@@ -51,6 +52,7 @@ class SegmentedSwitch extends PureComponent {
     } = this.props
 
     const containerClass = classnames(
+      className,
       theme.segmentedSwitch,
       theme[`spacing-${spacing}`],
       theme[`relevance-${relevance}`],
@@ -68,6 +70,10 @@ class SegmentedSwitch extends PureComponent {
 }
 
 SegmentedSwitch.propTypes = {
+  /**
+   * Additional CSS classes which can be applied to the table component.
+   */
+  className: PropTypes.string,
   /**
    * It disables/enables the component's functions.
    */
@@ -129,6 +135,7 @@ SegmentedSwitch.propTypes = {
 }
 
 SegmentedSwitch.defaultProps = {
+  className: '',
   disabled: false,
   relevance: 'normal',
   spacing: 'medium',


### PR DESCRIPTION
## Context
This PR adds `className` prop in `<SegmentedSwitch />`. With this, we can add other classes in the component.

## Checklist
- [ ] Add `classname` prop

## Linked Issues
- [ ] Resolves https://github.com/pagarme/tecnologia-vendas/issues/774

## How to test?
Knowing that this PR is helping with https://github.com/pagarme/linkapp/pull/245, you can test there with these steps:
- Go to `add/future-balance-container` in linkapp repository
- Generate a link from this branch in former-kit repository with `yarn link`
- Go to linkapp and `yarn link former-kit`
- Add a class in `<SpacedSegmentedSwitch />` component in  `src/containers/OperationDays/index.js`
- See if it works! :tada: 