### PR TITLE
Adiciona tamanho mobile no componente Modal

### DIFF
--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -18,10 +18,12 @@ const Modal = ({
   onRequestClose,
   size,
   theme,
+  verticalAlign,
 }) => {
   const modalClasses = classNames(
     theme.modal,
-    theme[size]
+    theme[size],
+    theme[verticalAlign]
   )
 
   return (
@@ -66,7 +68,7 @@ Modal.propTypes = {
    * Component's size.
    */
   size: PropTypes.oneOf([
-    'default', 'huge',
+    'mobile', 'default', 'huge',
   ]),
   /**
    * @see [ThemeProvider](#themeprovider) - Theme received from `consumeTheme` wrapper.
@@ -81,6 +83,12 @@ Modal.propTypes = {
     overlayBeforeClose: PropTypes.string,
     size: PropTypes.string,
   }),
+  /**
+   * Component's vertical align
+   */
+  verticalAlign: PropTypes.oneOf([
+    'top', 'center', 'bottom',
+  ]),
 }
 
 Modal.defaultProps = {
@@ -95,6 +103,7 @@ Modal.defaultProps = {
     overlayAfterOpen: '',
     overlayBeforeClose: '',
   },
+  verticalAlign: 'center',
 }
 
 export default consumeTheme(Modal)

--- a/stories/Modal/ModalWithMobileSize.js
+++ b/stories/Modal/ModalWithMobileSize.js
@@ -1,0 +1,78 @@
+import React, { useState } from 'react'
+import IconClose from 'emblematic-icons/svg/ClearClose32.svg'
+
+import {
+  Modal,
+  ModalActions,
+  ModalContent,
+  ModalSection,
+  ModalTitle,
+} from '../../src/Modal'
+
+import Button from '../../src/Button'
+
+const CallToAction = ({ onClick }) => (
+  <Button fill="flat" relevance="low" onClick={onClick}>
+    Modal with mobile size
+  </Button>
+)
+
+const ModalWithMobileSize = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const handleToggleModal = () => {
+    setIsOpen(!isOpen)
+  }
+
+  const handleCloseModal = () => {
+    setIsOpen(false)
+  }
+
+  return (
+    <div>
+      <CallToAction onClick={handleToggleModal} />
+      <Modal
+        label="Create a Transaction"
+        isOpen={isOpen}
+        onRequestClose={handleToggleModal}
+        size="mobile"
+      >
+        <ModalTitle
+          closeIcon={<IconClose width={16} height={16} />}
+          onClose={handleCloseModal}
+          title="Modal With Mobile Size"
+        />
+        <hr />
+        <ModalContent>
+          This is the modal Content with React Modal module
+        </ModalContent>
+
+        <ModalContent>
+          <ModalSection>
+            <ModalContent>
+              This is the modal Section
+            </ModalContent>
+          </ModalSection>
+        </ModalContent>
+        <ModalActions>
+          <Button
+            fill="outline"
+            size="default"
+            onClick={handleToggleModal}
+          >
+            Cancel
+          </Button>
+
+          <Button
+            size="default"
+            onClick={handleToggleModal}
+          >
+            Confirm
+          </Button>
+        </ModalActions>
+      </Modal>
+    </div>
+  )
+}
+
+export default ModalWithMobileSize

--- a/stories/Modal/index.js
+++ b/stories/Modal/index.js
@@ -5,6 +5,7 @@ import Section from '../Section'
 
 import ModalWithState from './ModalWithState'
 import ModalWithHugeSize from './ModalWithHugeSize'
+import ModalWithMobileSize from './ModalWithMobileSize'
 
 storiesOf('Modal', module)
   .add('Default', () => (
@@ -14,6 +15,9 @@ storiesOf('Modal', module)
       </Section>
       <Section>
         <ModalWithHugeSize />
+      </Section>
+      <Section>
+        <ModalWithMobileSize />
       </Section>
     </div>
   ))

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -25941,6 +25941,136 @@ exports[`Storyshots Modal Default 1`] = `
         </div>
       </div>
     </section>
+    <section
+      className=""
+    >
+      
+      <div>
+        <div>
+          <button
+            className="button flat lowRelevance default"
+            disabled={false}
+            onClick={[Function]}
+            type="button"
+          >
+            <span>
+              Modal with mobile size
+            </span>
+            <span
+              className="ripple"
+              style={
+                Object {
+                  "height": 0,
+                  "left": 0,
+                  "top": 0,
+                  "width": 0,
+                }
+              }
+            />
+          </button>
+          <div
+            className="modal"
+          >
+            <div
+              className="title"
+            >
+              <h2
+                className="centerAlign"
+              >
+                Modal With Mobile Size
+              </h2>
+              <button
+                className="button clean lowRelevance tiny iconButton"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <ClearClose32.svg
+                  height={16}
+                  width={16}
+                />
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
+                  }
+                />
+              </button>
+            </div>
+            <hr />
+            <div
+              className="content"
+            >
+              This is the modal Content with React Modal module
+            </div>
+            <div
+              className="content"
+            >
+              <div
+                className="section"
+              >
+                <div
+                  className="content"
+                >
+                  This is the modal Section
+                </div>
+              </div>
+            </div>
+            <div
+              className="actions"
+            >
+              <button
+                className="button outline normalRelevance default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span>
+                  Cancel
+                </span>
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
+                  }
+                />
+              </button>
+              <button
+                className="button flat normalRelevance default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <span>
+                  Confirm
+                </span>
+                <span
+                  className="ripple"
+                  style={
+                    Object {
+                      "height": 0,
+                      "left": 0,
+                      "top": 0,
+                      "width": 0,
+                    }
+                  }
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
   </div>
 </div>
 `;


### PR DESCRIPTION
## Context
Precisamos do modal compativel com tamanho mobile para uso no linkApp.

## Checklist
- [x] Adiciona resolução mobile.
- [x] Adiciona alinhamento vertical

## Linked Issues
- [x] Resolves https://github.com/pagarme/former-kit/issues/324

### Preview:
![image](https://user-images.githubusercontent.com/46823713/75818464-ae00c980-5d77-11ea-9809-9d4051777bdc.png)

### Como testar:
- no `former-kit-skin` entre na branch `add/modal-mobile-size`
- rode `yarn link`
- no `former-kit` entre na branch `add/modal-mobile-size` 
- rode `yarn link "former-kit-skin-pagarme"`
- rode `yarn storybook`
- cheque a historia do Modal com tamanho mobile