### PR TITLE
release 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {
@@ -35,7 +35,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "emblematic-icons": "0.7.1",
-    "former-kit-skin-pagarme": "1.6.0",
+    "former-kit-skin-pagarme": "1.7.0",
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6299,10 +6299,10 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-former-kit-skin-pagarme@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.6.0.tgz#34f1ded5523f6ea5896798589e8bf8c942b70405"
-  integrity sha512-2OWb+Y7BofM4Ut2/4lMlX6cm6lxFwvRNciFj4zGzN1R+1tiRvab3poA+krQnHNqlUSxIYGJfgaQcX5epDTU0RA==
+former-kit-skin-pagarme@1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.7.0.tgz#11b2853a54c816fbcf431d8fcd5ed08f0d709517"
+  integrity sha512-gWHj9VXPpH86GnvddX6rAAOsI5qgE1Gd1j6eFCeIXzHUW3XgfKve23SisxtRrJEWuCgVtQ/okfKfFFbS8fUdzg==
   dependencies:
     emblematic-icons "0.7.1"
     react-dates "18.4.1"


### PR DESCRIPTION
This release adds:
- Modal: mobile size #325
- bump former-kit-skin-pagarme to `1.7.0`

resolves #326 