### PR TITLE
dropdown: add SecondaryDropdown

### DIFF
--- a/src/Dropdown/Dropdown.js
+++ b/src/Dropdown/Dropdown.js
@@ -211,6 +211,7 @@ Dropdown.propTypes = {
    */
   size: PropTypes.oneOf([
     'tiny',
+    'huge',
   ]),
   /**
    * @see [ThemeProvider](#themeprovider) - Theme received from `consumeTheme` wrapper.

--- a/src/Dropdown/secondary-form/index.js
+++ b/src/Dropdown/secondary-form/index.js
@@ -1,0 +1,7 @@
+import ThemeConsumer from '../../ThemeConsumer'
+
+import Dropdown from '../Dropdown'
+
+const consumeTheme = ThemeConsumer('UISecondaryDropdownForm')
+
+export default consumeTheme(Dropdown)

--- a/stories/Dropdown/index.js
+++ b/stories/Dropdown/index.js
@@ -1,3 +1,3 @@
 import './form'
+import './secondaryForm'
 import './default'
-

--- a/stories/Dropdown/secondaryForm.js
+++ b/stories/Dropdown/secondaryForm.js
@@ -1,0 +1,88 @@
+import React, { useState } from 'react'
+import { storiesOf } from '@storybook/react'
+import Section from '../Section'
+import Dropdown from '../../src/Dropdown/secondary-form'
+
+const options = [
+  {
+    name: 'Github',
+    value: 'github',
+  },
+  {
+    name: 'Open Source',
+    value: 'open-source',
+  },
+  {
+    name: 'Pilot',
+    value: 'pilot',
+  },
+]
+
+const DropdownState = ({
+  disabled,
+  error,
+  placeholder,
+  size,
+  value,
+}) => {
+  const [selected, setSelected] = useState(value)
+
+  return (
+    <div>
+      <Dropdown
+        options={options}
+        name="Things"
+        onChange={event => setSelected(event.target.value)}
+        value={selected}
+        disabled={disabled}
+        placeholder={placeholder}
+        error={error}
+        size={size}
+      />
+      <p>Selected: {selected}</p>
+    </div>
+  )
+}
+
+DropdownState.defaultProps = {
+  disabled: false,
+  error: '',
+  placeholder: '',
+  size: null,
+  value: '',
+}
+
+storiesOf('Dropdown', module)
+  .add('SecondaryForm', () => (
+    <div>
+      <Section title="Default">
+        <DropdownState />
+      </Section>
+
+      <Section title="Huge dropdown">
+        <DropdownState placeholder="Select" size="huge" />
+      </Section>
+
+      <Section title="With placeholder">
+        <DropdownState placeholder="Select" />
+      </Section>
+
+      <Section title="Error">
+        <DropdownState error="Something went wrong" />
+      </Section>
+
+      <Section title="Disabled">
+        <DropdownState disabled />
+      </Section>
+
+      <Section title="Disabled with placeholder">
+        <DropdownState disabled placeholder="Select" />
+      </Section>
+
+      <Section title="dropdown with value">
+        <DropdownState
+          value="open-source"
+        />
+      </Section>
+    </div>
+  ))

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -14349,6 +14349,455 @@ exports[`Storyshots Dropdown Form 1`] = `
 </div>
 `;
 
+exports[`Storyshots Dropdown SecondaryForm 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <div
+    className="typography"
+  >
+    <section
+      className=""
+    >
+      <h2>
+        Default
+      </h2>
+      <div>
+        <div>
+          <div
+            className="dropdown"
+          >
+            
+            <select
+              className="select"
+              disabled={false}
+              id="Things-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="placeholder"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                
+              </option>
+              <option
+                className="option"
+                value="github"
+              >
+                Github
+              </option>
+              <option
+                className="option"
+                value="open-source"
+              >
+                Open Source
+              </option>
+              <option
+                className="option"
+                value="pilot"
+              >
+                Pilot
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            
+          </div>
+          <p>
+            Selected: 
+            
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        Huge dropdown
+      </h2>
+      <div>
+        <div>
+          <div
+            className="dropdown huge"
+          >
+            
+            <select
+              className="select"
+              disabled={false}
+              id="Things-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="placeholder"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                Select
+              </option>
+              <option
+                className="option"
+                value="github"
+              >
+                Github
+              </option>
+              <option
+                className="option"
+                value="open-source"
+              >
+                Open Source
+              </option>
+              <option
+                className="option"
+                value="pilot"
+              >
+                Pilot
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            
+          </div>
+          <p>
+            Selected: 
+            
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        With placeholder
+      </h2>
+      <div>
+        <div>
+          <div
+            className="dropdown"
+          >
+            
+            <select
+              className="select"
+              disabled={false}
+              id="Things-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="placeholder"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                Select
+              </option>
+              <option
+                className="option"
+                value="github"
+              >
+                Github
+              </option>
+              <option
+                className="option"
+                value="open-source"
+              >
+                Open Source
+              </option>
+              <option
+                className="option"
+                value="pilot"
+              >
+                Pilot
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            
+          </div>
+          <p>
+            Selected: 
+            
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        Error
+      </h2>
+      <div>
+        <div>
+          <div
+            className="dropdown error"
+          >
+            
+            <select
+              className="select"
+              disabled={false}
+              id="Things-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="placeholder"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                
+              </option>
+              <option
+                className="option"
+                value="github"
+              >
+                Github
+              </option>
+              <option
+                className="option"
+                value="open-source"
+              >
+                Open Source
+              </option>
+              <option
+                className="option"
+                value="pilot"
+              >
+                Pilot
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            <p
+              className="secondaryText"
+            >
+              Something went wrong
+            </p>
+          </div>
+          <p>
+            Selected: 
+            
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        Disabled
+      </h2>
+      <div>
+        <div>
+          <div
+            className="dropdown disabled"
+          >
+            
+            <select
+              className="select"
+              disabled={true}
+              id="Things-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="placeholder"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                
+              </option>
+              <option
+                className="option"
+                value="github"
+              >
+                Github
+              </option>
+              <option
+                className="option"
+                value="open-source"
+              >
+                Open Source
+              </option>
+              <option
+                className="option"
+                value="pilot"
+              >
+                Pilot
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            
+          </div>
+          <p>
+            Selected: 
+            
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        Disabled with placeholder
+      </h2>
+      <div>
+        <div>
+          <div
+            className="dropdown disabled"
+          >
+            
+            <select
+              className="select"
+              disabled={true}
+              id="Things-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="placeholder"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                Select
+              </option>
+              <option
+                className="option"
+                value="github"
+              >
+                Github
+              </option>
+              <option
+                className="option"
+                value="open-source"
+              >
+                Open Source
+              </option>
+              <option
+                className="option"
+                value="pilot"
+              >
+                Pilot
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            
+          </div>
+          <p>
+            Selected: 
+            
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
+        dropdown with value
+      </h2>
+      <div>
+        <div>
+          <div
+            className="dropdown"
+          >
+            
+            <select
+              className="select"
+              disabled={false}
+              id="Things-shortid-mock"
+              onBlur={[Function]}
+              onChange={[Function]}
+              onFocus={[Function]}
+              value="open-source"
+            >
+              <option
+                className="option placeholder"
+                disabled={true}
+                hidden={true}
+                value="placeholder"
+              >
+                
+              </option>
+              <option
+                className="option"
+                value="github"
+              >
+                Github
+              </option>
+              <option
+                className="option active"
+                value="open-source"
+              >
+                Open Source
+              </option>
+              <option
+                className="option"
+                value="pilot"
+              >
+                Pilot
+              </option>
+            </select>
+            <span
+              className="arrow"
+            >
+              <svg />
+            </span>
+            
+          </div>
+          <p>
+            Selected: 
+            open-source
+          </p>
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
+`;
+
 exports[`Storyshots Flexbox Align Items 1`] = `
 <div
   className="storybook-readme-story"


### PR DESCRIPTION
## Context

This PR add the new dropdown variant that is required for the Onboarding history (https://github.com/pagarme/credenciamento/issues/437 and https://github.com/pagarme/pilot/issues/1579).

css content: https://github.com/pagarme/former-kit-skin-pagarme/pull/233

## Checklist
- [ ] Add SecondaryDropdown styles

## Linked Issues
- [ ] Issue https://github.com/pagarme/credenciamento/issues/471

## Screenshots
<!-- Add some images to have a preview of your task, to help developers and designers to undestand easily which you're working on. -->

### Layout:

Telas: https://www.figma.com/file/kVlmDxHiI7FQcOARicddD2/Onboarding?node-id=0%3A1

![image](https://user-images.githubusercontent.com/13531067/76892275-3186e400-6869-11ea-9a88-1ad85c49ad3e.png)

### Preview:
![image](https://user-images.githubusercontent.com/13531067/76892394-6c891780-6869-11ea-9732-1275613c1da7.png)


