### PR TITLE
release 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {
@@ -35,7 +35,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "emblematic-icons": "0.7.1",
-    "former-kit-skin-pagarme": "1.7.0",
+    "former-kit-skin-pagarme": "1.8.0",
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6299,10 +6299,10 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-former-kit-skin-pagarme@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.7.0.tgz#11b2853a54c816fbcf431d8fcd5ed08f0d709517"
-  integrity sha512-gWHj9VXPpH86GnvddX6rAAOsI5qgE1Gd1j6eFCeIXzHUW3XgfKve23SisxtRrJEWuCgVtQ/okfKfFFbS8fUdzg==
+former-kit-skin-pagarme@1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-1.8.0.tgz#c1bfe1997872db7995f299da1cdf90953bf0f787"
+  integrity sha512-ecygYKbYfPhlRk+rCflWFMfnLGkmrTKQQbgOjpvA4+HgoA9MCioqUJj6OGWNy2TtrW55YDbbaybW51qgeRwQ+Q==
   dependencies:
     emblematic-icons "0.7.1"
     react-dates "18.4.1"


### PR DESCRIPTION
This release adds:
- SecondaryButton #323
- SecondaryDropdown #329
- Bump acorn related dependencies #328
- bump former-kit-skin-pagarme to `1.8.0`