### PR TITLE
fix: card clickacle area

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -74,7 +74,7 @@ const Button = ({
     setRipple(createRipple(e))
 
     if (onClick) {
-      onClick()
+      onClick(e)
     }
   }
 

--- a/src/Card/CardSectionDoubleLineTitle.js
+++ b/src/Card/CardSectionDoubleLineTitle.js
@@ -37,7 +37,13 @@ const CardSectionDoubleLineTitle = ({
   )
 
   return (
-    <div className={headerClassNames}>
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events
+    <div
+      className={headerClassNames}
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+    >
       <div className={theme.doubleLineHead}>
         <div className={theme.doubleLineTitle}>
           <span className={theme.sectionIconBox}>
@@ -55,8 +61,8 @@ const CardSectionDoubleLineTitle = ({
           <Button
             fill="outline"
             icon={getArrowIcon({ collapsed, icons })}
-            onClick={onClick}
             relevance="low"
+            onKey={onClick}
             size="default"
             type="button"
           />

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -43,9 +43,12 @@ class Popover extends Component {
     }
   }
 
-  handleOnClick () {
+  handleOnClick (e) {
     const { onClick } = this.props
     const { visible } = this.state
+
+    e.stopPropagation()
+
     if (!onClick) {
       this.setState({
         visible: !visible,

--- a/stories/Card/CardSectionDoubleLineTitle.js
+++ b/stories/Card/CardSectionDoubleLineTitle.js
@@ -47,7 +47,10 @@ const renderActions = () => (
       fill="outline"
       icon={<IconCalendar width={16} height={16} />}
       key="Item 1"
-      onClick={() => action('item 1')}
+      onClick={(e) => {
+        e.stopPropagation()
+        action('item 1')
+      }}
       size="default"
     />
 

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -9967,6 +9967,9 @@ feugiat hendrerit. Vivamus eleifend odio a congue consectetur.
               >
                 <div
                   className="sectionDoubleLineTitle clickableTitle"
+                  onClick={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
                   <div
                     className="doubleLineHead"
@@ -10118,6 +10121,9 @@ feugiat hendrerit. Vivamus eleifend odio a congue consectetur.
               >
                 <div
                   className="sectionDoubleLineTitle clickableTitle"
+                  onClick={[Function]}
+                  role="button"
+                  tabIndex={0}
                 >
                   <div
                     className="doubleLineHead"


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->

## Context
O componente CardSectionDoubleLineTitle atualmente só é clicável na seta ao final do card. Muitos clientes acabam clicando no título ou em outros lugares para abrir o componente, poderíamos então deixar toda a seção de cima clicável para melhorar a usabilidade.