### PR TITLE
chore: add new arrow props to popover component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {
@@ -35,7 +35,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "emblematic-icons": "0.12.0",
-    "former-kit-skin-pagarme": "2.7.0",
+    "former-kit-skin-pagarme": "2.8.0",
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",

--- a/src/Header/HeaderMenu.js
+++ b/src/Header/HeaderMenu.js
@@ -15,6 +15,7 @@ const HeaderMenu = ({
   title,
 }) => (
   <Popover
+    arrow={false}
     content={children}
     placement="bottomEnd"
   >

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -62,6 +62,7 @@ class Popover extends Component {
 
   render () {
     const {
+      arrow,
       base,
       children,
       content,
@@ -70,6 +71,7 @@ class Popover extends Component {
     } = this.props
 
     const { visible } = this.state
+    const withoutArrow = arrow ? '' : 'withoutArrow'
 
     return (
       <div
@@ -92,7 +94,8 @@ class Popover extends Component {
                 classNames(
                   theme.popover,
                   theme[base],
-                  theme[placement]
+                  theme[placement],
+                  theme[withoutArrow]
                 )
               }
               key="popover"
@@ -107,6 +110,10 @@ class Popover extends Component {
 }
 
 Popover.propTypes = {
+  /**
+   * Popover set arrow.
+   */
+  arrow: PropTypes.bool,
   /**
    * Popover base theme.
    */
@@ -155,6 +162,7 @@ Popover.propTypes = {
     base: PropTypes.string,
     popover: PropTypes.string,
     target: PropTypes.string,
+    withoutArrow: PropTypes.string,
   }),
   /**
    * The prop that indicates if the popover is visible or not.
@@ -163,6 +171,7 @@ Popover.propTypes = {
 }
 
 Popover.defaultProps = {
+  arrow: true,
   base: null,
   closeWhenClickOutside: true,
   onClick: null,

--- a/stories/Popover/index.js
+++ b/stories/Popover/index.js
@@ -20,8 +20,9 @@ import PopoverControl from './PopoverControl'
 
 import style from './style.css'
 
-const PopoverExample = ({ base, placement }) => (
+const PopoverExample = ({ arrow = true, base, placement }) => (
   <Popover
+    arrow={arrow}
     content={<Menu />}
     base={base}
     placement={placement}
@@ -51,6 +52,11 @@ storiesOf('Popover', module)
   .add('With base dark', () => (
     <Section>
       <PopoverExample base="dark" />
+    </Section>
+  ))
+  .add('Without arrow', () => (
+    <Section>
+      <PopoverExample arrow={false} />
     </Section>
   ))
   .add('Positions', () => (

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -28760,6 +28760,49 @@ exports[`Storyshots Popover With base dark 1`] = `
 </div>
 `;
 
+exports[`Storyshots Popover Without arrow 1`] = `
+<div
+  className="storybook-readme-story"
+>
+  <section
+    className="typography"
+  >
+    
+    <div>
+      <div
+        className="target"
+        onClick={[Function]}
+        role="presentation"
+      >
+        <button
+          className="button flat normalRelevance default"
+          disabled={false}
+          onClick={[Function]}
+          type="button"
+        >
+          <span
+            className="textButton"
+          >
+            click me
+          </span>
+          <span
+            className="ripple"
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "top": 0,
+                "width": 0,
+              }
+            }
+          />
+        </button>
+      </div>
+    </div>
+  </section>
+</div>
+`;
+
 exports[`Storyshots Progress Linear 1`] = `
 <div
   className="storybook-readme-story"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6304,10 +6304,10 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-former-kit-skin-pagarme@2.7.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-2.7.0.tgz#42c1a150e1cfb3d2275b284584b6078869da7a22"
-  integrity sha512-WmnpP0CTLEJaRCujunntshRTxf5ECMXzO0IT8KcckKVET2L+tkrqielLewKp+ER2eG7mOaRTh4AKPplK2BG4Ww==
+former-kit-skin-pagarme@2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/former-kit-skin-pagarme/-/former-kit-skin-pagarme-2.8.0.tgz#ee412a9f0041c606364a85d7d3a7884f37fcb590"
+  integrity sha512-PEfQGLBDbvp8P6LK7r6t06jV97rplfqIwU1IAp7ovuSFi8TaIwybO97MHS8niAlKAgU9AKUr8xowHUsqRzwKMg==
   dependencies:
     emblematic-icons "0.11.0"
     react-dates "18.4.1"


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->

## Context
<!-- What problem are you trying to solve? -->
Este pr adiciona uma nova prop para o component de `popover`

## Como testar?
- Baixar o `former-kit-skin-pagarme` que possue a branch com o mesmo nome dessa 
- Executar o `yarn`
- Executar o `yarn build` no `former-kit-skin-pagarme`
- Executar o `yarn link` no `former-kit-skin-pagarme`
- Baixar a branch `chore/adjust-popover`
- Executar o `yarn`
- executar o comando `yarn link former-kit-skin-pagarme`
- Executar o comando `yarn install --force`
- Executar o `storybook` e checar o popover `withoutArrow`
