### PR TITLE
[EXP-693] Refactor/react click outside

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "case-sensitive-paths-webpack-plugin": "2.1.2",
     "chalk": "2.3.0",
     "chokidar-cli": "2.0.0",
+    "create-react-class": "15.6.2",
     "css-loader": "2.1.0",
     "dotenv": "6.2.0",
     "enzyme": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "classnames": "2.2.6",
     "emblematic-icons": "0.12.0",
     "former-kit-skin-pagarme": "2.10.0",
+    "hoist-non-react-statics": "2.1.1",
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "promise": "8.0.2",
     "prop-types": "15.6.2",
     "ramda": "0.26.1",
-    "react-click-outside": "3.0.1",
     "react-dates": "18.4.1",
     "react-input-mask": "2.0.4",
     "react-maskedinput": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
-import ClickOutside from 'react-click-outside'
+import ClickOutside from './ReactClickOutside'
 import {
   grow,
   Transition,

--- a/src/Popover/ReactClickOutside.js
+++ b/src/Popover/ReactClickOutside.js
@@ -1,0 +1,77 @@
+
+import hoistNonReactStatic from 'hoist-non-react-statics'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+
+function enhanceWithClickOutside (Component) {
+  const componentName = Component.displayName || Component.name
+
+  class EnhancedComponent extends React.Component {
+    constructor (props) {
+      super(props)
+      this.handleClickOutside = this.handleClickOutside.bind(this)
+
+      this.domNode = null
+      this.wrappedInstance = null
+    }
+
+    componentDidMount () {
+      document.addEventListener('click', this.handleClickOutside, true)
+    }
+
+    componentWillUnmount () {
+      document.removeEventListener('click', this.handleClickOutside, true)
+    }
+
+    handleClickOutside (e) {
+      const { domNode } = this
+
+      let target = e && e.target
+
+      if (e && e.composedPath && e.composedPath().length > 0) {
+        [target] = e.composedPath()
+      }
+
+      if (
+        (!domNode || !domNode.contains(target))
+        && this.wrappedInstance
+        && typeof this.wrappedInstance.handleClickOutside === 'function'
+      ) {
+        this.wrappedInstance.handleClickOutside(e)
+      }
+    }
+
+    render () {
+      const { wrappedRef, ...rest } = this.props
+
+      return (
+        <Component
+          {...rest}
+          ref={(c) => {
+            this.wrappedInstance = c
+            this.domNode = ReactDOM.findDOMNode(c) // eslint-disable-line react/no-find-dom-node
+            if (wrappedRef) {
+              wrappedRef(c)
+            }
+          }}
+        />
+      )
+    }
+  }
+
+  EnhancedComponent.displayName = `clickOutside(${componentName})`
+
+  EnhancedComponent.propTypes = {
+    ...Component.propTypes,
+    wrappedRef: PropTypes.node,
+  }
+
+  EnhancedComponent.defaultProps = {
+    ...Component.defaultProps,
+  }
+
+  return hoistNonReactStatic(EnhancedComponent, Component)
+}
+
+module.exports = enhanceWithClickOutside

--- a/src/Popover/ReactClickOutside.js
+++ b/src/Popover/ReactClickOutside.js
@@ -78,4 +78,4 @@ function enhanceWithClickOutside (Component) {
   return hoistNonReactStatic(EnhancedComponent, Component)
 }
 
-module.exports = enhanceWithClickOutside
+export default enhanceWithClickOutside

--- a/src/Popover/ReactClickOutside.js
+++ b/src/Popover/ReactClickOutside.js
@@ -1,4 +1,5 @@
 
+// based on https://github.com/kentor/react-click-outside
 import hoistNonReactStatic from 'hoist-non-react-statics'
 import React from 'react'
 import ReactDOM from 'react-dom'
@@ -64,7 +65,10 @@ function enhanceWithClickOutside (Component) {
 
   EnhancedComponent.propTypes = {
     ...Component.propTypes,
-    wrappedRef: PropTypes.node,
+    wrappedRef: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.shape({ current: PropTypes.elementType }),
+    ]),
   }
 
   EnhancedComponent.defaultProps = {

--- a/src/Popover/ReactClickOutside.test.js
+++ b/src/Popover/ReactClickOutside.test.js
@@ -3,15 +3,15 @@
 
 global.requestAnimationFrame = callback => setTimeout(callback, 0);
 
-const Adapter = require('enzyme-adapter-react-16');
-const { configure } = require('enzyme');
+import Adapter from 'enzyme-adapter-react-16';
+import { configure } from 'enzyme';
 
 configure({ adapter: new Adapter() });
 
-const createReactClass = require('create-react-class');
-const enhanceWithClickOutside = require('./ReactClickOutside');
-const enzyme = require('enzyme');
-const React = require('react');
+import createReactClass from 'create-react-class';
+import enhanceWithClickOutside from './ReactClickOutside';
+import enzyme from 'enzyme';
+import React from 'react';
 
 const mountNode = document.createElement('div');
 document.body.appendChild(mountNode);

--- a/src/Popover/ReactClickOutside.test.js
+++ b/src/Popover/ReactClickOutside.test.js
@@ -1,0 +1,252 @@
+// copied from https://github.com/kentor/react-click-outside
+/* eslint-disable */
+
+global.requestAnimationFrame = callback => setTimeout(callback, 0);
+
+const Adapter = require('enzyme-adapter-react-16');
+const { configure } = require('enzyme');
+
+configure({ adapter: new Adapter() });
+
+const createReactClass = require('create-react-class');
+const enhanceWithClickOutside = require('./ReactClickOutside');
+const enzyme = require('enzyme');
+const React = require('react');
+
+const mountNode = document.createElement('div');
+document.body.appendChild(mountNode);
+
+function mount(element) {
+  return enzyme.mount(element, { attachTo: mountNode });
+}
+
+function simulateClick(node) {
+  const event = new window.MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    view: window,
+  });
+  node.dispatchEvent(event);
+  return event;
+}
+
+describe('enhanceWithClickOutside', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = undefined;
+  });
+
+  afterEach(() => {
+    if (wrapper && wrapper.unmount) {
+      wrapper.unmount();
+    }
+  });
+
+  it('calls handleClickOutside when clicked outside of component', () => {
+    const clickInsideSpy = jest.fn();
+    const clickOutsideSpy = jest.fn();
+
+    const EnhancedComponent = (() => {
+      class WrappedComponent extends React.Component {
+        constructor() {
+          super();
+          this.handleClick = this.handleClick.bind(this);
+        }
+
+        handleClick() {
+          clickInsideSpy();
+        }
+
+        handleClickOutside(e) {
+          this.testBoundToComponent(e);
+        }
+
+        testBoundToComponent(e) {
+          clickOutsideSpy(e);
+        }
+
+        render() {
+          return (
+            <div id="enhancedNode" onClick={this.handleClick}>
+              <div id="nestedNode" />
+            </div>
+          );
+        }
+      }
+
+      return enhanceWithClickOutside(WrappedComponent);
+    })();
+
+    class Root extends React.Component {
+      render() {
+        return (
+          <div>
+            <EnhancedComponent />
+            <div id="outsideNode" />
+          </div>
+        );
+      }
+    }
+
+    wrapper = mount(<Root />);
+
+    const enhancedNode = wrapper.find('#enhancedNode').getDOMNode();
+    const nestedNode = wrapper.find('#nestedNode').getDOMNode();
+    const outsideNode = wrapper.find('#outsideNode').getDOMNode();
+
+    simulateClick(enhancedNode);
+    expect(clickInsideSpy.mock.calls.length).toBe(1);
+    expect(clickOutsideSpy.mock.calls.length).toBe(0);
+
+    simulateClick(nestedNode);
+    expect(clickInsideSpy.mock.calls.length).toBe(2);
+    expect(clickOutsideSpy.mock.calls.length).toBe(0);
+
+    // Stop propagation in the outside node should not prevent the
+    // handleOutsideClick handler from being called
+    outsideNode.addEventListener('click', e => e.stopPropagation());
+
+    const event = simulateClick(outsideNode);
+    expect(clickOutsideSpy).toHaveBeenCalledWith(event);
+  });
+
+  it('calls handleClickOutside even if wrapped component renders null', () => {
+    const clickOutsideSpy = jest.fn();
+
+    const EnhancedComponent = (() => {
+      class WrappedComponent extends React.Component {
+        handleClickOutside() {
+          clickOutsideSpy();
+        }
+
+        render() {
+          return null;
+        }
+      }
+
+      return enhanceWithClickOutside(WrappedComponent);
+    })();
+
+    wrapper = mount(<EnhancedComponent />);
+
+    // We shouldn't TypeError when we try to call handleClickOutside
+    expect(() => {
+      const instance = wrapper.instance();
+      instance.handleClickOutside();
+    }).not.toThrow(TypeError);
+
+    // If the component returns null, technically every click is an outside
+    // click, so we should call the inner handleClickOutside always
+    expect(clickOutsideSpy.mock.calls.length).toBe(1);
+  });
+
+  it('does not call handleClickOutside when unmounted', () => {
+    const clickOutsideSpy = jest.fn();
+
+    const EnhancedComponent = (() => {
+      class WrappedComponent extends React.Component {
+        handleClickOutside() {
+          clickOutsideSpy();
+        }
+
+        render() {
+          return <div />;
+        }
+      }
+
+      return enhanceWithClickOutside(WrappedComponent);
+    })();
+
+    class Root extends React.Component {
+      constructor() {
+        super();
+        this.state = {
+          showEnhancedComponent: true,
+        };
+      }
+
+      render() {
+        return (
+          <div>
+            {this.state.showEnhancedComponent && <EnhancedComponent />}
+            <div id="outsideNode" />
+          </div>
+        );
+      }
+    }
+
+    wrapper = mount(<Root />);
+    const outsideNode = wrapper.find('#outsideNode').getDOMNode();
+
+    expect(clickOutsideSpy.mock.calls.length).toBe(0);
+    simulateClick(outsideNode);
+    expect(clickOutsideSpy.mock.calls.length).toBe(1);
+
+    wrapper.setState({ showEnhancedComponent: false });
+
+    simulateClick(outsideNode);
+    expect(clickOutsideSpy.mock.calls.length).toBe(1);
+  });
+
+  it('does nothing if handleClickOutside is not implemented', () => {
+    const EnhancedComponent = (() => {
+      class WrappedComponent extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+
+      return enhanceWithClickOutside(WrappedComponent);
+    })();
+    wrapper = mount(<EnhancedComponent />);
+    wrapper.instance().handleClickOutside({});
+  });
+
+  it('takes wrappedRef prop', () => {
+    const EnhancedComponent = (() => {
+      class WrappedComponent extends React.Component {
+        wrappedInstanceMethod() {}
+
+        render() {
+          return null;
+        }
+      }
+
+      return enhanceWithClickOutside(WrappedComponent);
+    })();
+
+    let instance;
+
+    wrapper = mount(
+      <EnhancedComponent
+        wrappedRef={c => {
+          instance = c;
+        }}
+      />
+    );
+
+    expect(typeof instance.wrappedInstanceMethod).toBe('function');
+  });
+
+  describe('displayName', () => {
+    it('gets set for React.createClass', () => {
+      const ReactClass = createReactClass({
+        displayName: 'ReactClass',
+        handleClickOutside() {},
+        render() {},
+      });
+      const Wrapped = enhanceWithClickOutside(ReactClass);
+      expect(Wrapped.displayName).toBe('clickOutside(ReactClass)');
+    });
+
+    it('gets set for ES6 classes', () => {
+      class ES6Class extends React.Component {
+        handleClickOutside() {}
+        render() {}
+      }
+      const Wrapped = enhanceWithClickOutside(ES6Class);
+      expect(Wrapped.displayName).toBe('clickOutside(ES6Class)');
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4580,6 +4580,15 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-react-class@15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.2.tgz#cf1ed15f12aad7f14ef5f2dfe05e6c42f91ef02a"
+  integrity sha1-zx7RXxKq1/FO9fLf4F5sQvke8Co=
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 create-react-context@<=0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
@@ -6221,7 +6230,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4:
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
@@ -7216,7 +7225,12 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.1.1.tgz#71f47fe91400f57d55e867277e3a5013829dcb45"
+  integrity sha1-cfR/6RQA9X1V6GcnfjpQE4Kdy0U=
+
+hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -12216,13 +12230,6 @@ react-addons-shallow-compare@^15.6.2:
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
-
-react-click-outside@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
-  integrity sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==
-  dependencies:
-    hoist-non-react-statics "^2.1.1"
 
 react-clientside-effect@^1.2.0:
   version "1.2.2"


### PR DESCRIPTION
## Context
O componente Popover utiliza o o pacote react-click-outside, para saber quando o usuário clica fora da área do popover. O problema é que esse pacote não funciona corretamente dentro de um shadow dom (O popover abre e fecha imediatamente).

Isso acontece porque quando esse pacote é usado com shadow-dom, o `event.target` do evento de click, retorna o shadow-dom e não o elemento correto dentro do shadow-dom. Por isso, foi necessário fazer um componente internamente dentro do former-kit, baseado no react-click-outside, modificando o comportamento para que funcione também com shadow-dom.

## Checklist
- [x] Remover pacote react-click-outside
- [x] Alterar componente do pacote react-click-outside para usar `event.composedPath()` para pegar o target correto
- [x] Instalar novas dependências usadas pelo componente ReactClickOutside
- [x] Adicionar componente ReactClickOutside (Já modificado) na pasta de Popover

## Como testar no former-kit
1. Rodar testes do former-kit e garantir que os testes (antigos e os do ReactClickOutside) estão passando.

## Como testar na pilot
1. Usar o npm link no former-kit e linkar na pilot
2. Testar os lugares que usam Popover na aplicação e garantir que tudo continua funcionando

## Como testar no SPA de balance
1. Entrar na branch release/balance-mfe da pilot
2. Usar o npm link no former-kit e linkar na pilot
3. Gerar o build da aplicação e servir localmente.
4. Importar a aplicação dentro de um shadow dom e garantir que o Popover de filtro de data do extrato, funciona corretamente.