### PR TITLE
Fix/use ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import classNames from 'classnames'
 import ReactModal from 'react-modal'
@@ -26,7 +26,7 @@ const Modal = ({
     theme[verticalAlign]
   )
 
-  const ref = useRef(null)
+  const ref = React.useRef(null)
 
   let rootNode = null
   if (ref.current) {


### PR DESCRIPTION
## Context
Esse PR tem o objetivo de mudar a forma de como o hook useRef é importado no componente de Modal.

Anteriormente ele era importado da seguinte maneira:
`import { useRef } from 'React'`

Agora vai se utilizar assim:
`React.useRef(null)`

Isto é necessário, pois desta forma é possível usar o spy do jest, desta forma:

`jest.spyOn(React, 'useRef').mockReturnValueOnce({ current: refNode })`

Como a `testling-library/react`, não funciona com useRef, a forma acima permite que seja possível mockar a ref para que os testes que usam modais, funcionem.