### PR TITLE
[EXP-879] Componentizar botão sem padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "2.10.4",
+  "version": "2.11.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {
@@ -35,7 +35,7 @@
   "dependencies": {
     "classnames": "2.2.6",
     "emblematic-icons": "0.12.0",
-    "former-kit-skin-pagarme": "2.10.4",
+    "former-kit-skin-pagarme": "2.11.0",
     "hoist-non-react-statics": "2.1.1",
     "promise": "8.0.2",
     "prop-types": "15.6.2",

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -57,6 +57,7 @@ const Button = ({
   fullWidth,
   icon,
   iconAlignment,
+  inline,
   loading,
   onClick,
   relevance,
@@ -115,6 +116,7 @@ const Button = ({
       [theme.circle]: !isNil(icon) && isNil(children) && circle,
       [theme.hiddenChildren]: !displayChildrenWhenLoading && loading,
       [theme.fullWidth]: fullWidth,
+      [theme.inline]: inline,
     }
   )
 
@@ -197,6 +199,10 @@ Button.propTypes = {
     'start', 'end',
   ]),
   /**
+  * Defines if button has no paddings to stay inline with texts
+  */
+  inline: PropTypes.bool,
+  /**
    * Indicates if the button is at loading state.
    */
   loading: PropTypes.bool,
@@ -232,6 +238,7 @@ Button.propTypes = {
     highRelevance: PropTypes.string,
     huge: PropTypes.string,
     iconButton: PropTypes.string,
+    inline: PropTypes.string,
     lowRelevance: PropTypes.string,
     normalRelevance: PropTypes.string,
     outline: PropTypes.string,
@@ -257,6 +264,7 @@ Button.defaultProps = {
   fullWidth: false,
   icon: null,
   iconAlignment: 'start',
+  inline: false,
   loading: false,
   onClick: null,
   relevance: 'normal',

--- a/src/Button/Button.md
+++ b/src/Button/Button.md
@@ -43,6 +43,16 @@ And the button can be disabled:
 </div>
 ```
 
+You can put the button inside a text!
+```jsx
+<div>
+  <p>
+    your text
+    <Button inline>Call to Action</Button>
+  </p>
+</div>
+```
+
 The button can have an icon!
 ```jsx
 const IconAdd = require('emblematic-icons/svg/Add24.svg').default;

--- a/stories/Button/default.js
+++ b/stories/Button/default.js
@@ -192,6 +192,23 @@ storiesOf('Buttons', module)
         </div>
       </Section>
 
+      <Section title="Inline">
+        <div className={styles.spacingAround}>
+          <p>
+            Use with text
+            <Button inline fill="clean" size="huge">Inline</Button>
+          </p>
+          <p>
+            Use with text
+            <Button inline fill="clean" relevance="high" size="huge">Inline</Button>
+          </p>
+          <p>
+            Use with text
+            <Button inline fill="clean" relevance="low" size="huge">Inline</Button>
+          </p>
+        </div>
+      </Section>
+
       <Section title="Icon only">
         <div className={styles.spacingAround}>
           <Button icon={<IconAdd width={12} height={12} />} />

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -1303,6 +1303,95 @@ exports[`Storyshots Buttons Default 1`] = `
       className=""
     >
       <h2>
+        Inline
+      </h2>
+      <div>
+        <div>
+          <p>
+            Use with text
+            <button
+              className="button clean normalRelevance huge inline"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="textButton"
+              >
+                Inline
+              </span>
+              <span
+                className="ripple"
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0,
+                  }
+                }
+              />
+            </button>
+          </p>
+          <p>
+            Use with text
+            <button
+              className="button clean highRelevance huge inline"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="textButton"
+              >
+                Inline
+              </span>
+              <span
+                className="ripple"
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0,
+                  }
+                }
+              />
+            </button>
+          </p>
+          <p>
+            Use with text
+            <button
+              className="button clean lowRelevance huge inline"
+              disabled={false}
+              onClick={[Function]}
+              type="button"
+            >
+              <span
+                className="textButton"
+              >
+                Inline
+              </span>
+              <span
+                className="ripple"
+                style={
+                  Object {
+                    "height": 0,
+                    "left": 0,
+                    "top": 0,
+                    "width": 0,
+                  }
+                }
+              />
+            </button>
+          </p>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
         Icon only
       </h2>
       <div>


### PR DESCRIPTION
## Context
Estratégia para componentizar botão sem padding

## Checklist
- [x] Adicionar prop `inline` no componente `Button`

## Linked Issues
- [Estratégia para componentizar botão sem padding](https://mundipagg.atlassian.net/secure/RapidBoard.jspa?rapidView=185&projectKey=EXP&modal=detail&selectedIssue=EXP-879)


### Preview:
**Preview com former-kit-skin-pagarme:**
![image](https://user-images.githubusercontent.com/28263075/128194429-1bdac593-5649-44f1-a786-2787935b1c0d.png)
