### PR TITLE
[MDX-1483] Adiciona prop charMask no InputMask

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -126,6 +126,7 @@ class Input extends React.PureComponent {
     const {
       disabled,
       mask,
+      maskChar,
       multiline,
       onChange,
       renderer,
@@ -150,6 +151,7 @@ class Input extends React.PureComponent {
             1: '[0-9]',
           }}
           mask={mask}
+          maskChar={maskChar}
           onChange={disabled ? null : onChange}
           onBlur={this.handleBlur}
           onFocus={this.handleFocus}
@@ -338,6 +340,11 @@ Input.propTypes = {
    * Allow multiline texts if the component type is text.
    * This prop is prioritized over the render options mask and renderer
    */
+  maskChar: PropTypes.string,
+  /**
+   * Character to cover unfilled parts of the mask. Default character is "_".
+   * If set to null or empty string, unfilled parts will be empty as in ordinary input.
+   */
   multiline: validateMultiline,
   /**
    * Input's name.
@@ -423,6 +430,7 @@ Input.defaultProps = {
   inputRef: null,
   label: '',
   mask: '',
+  maskChar: '_',
   multiline: false,
   name: '',
   onBlur: null,

--- a/src/Input/Input.test.js
+++ b/src/Input/Input.test.js
@@ -132,6 +132,29 @@ describe('Input', () => {
       expect(component.html()).toContain('4151 1124 ____ ____')
     })
 
+    it('should mount with a mask without masked char', () => {
+      const onChange = jest.fn()
+
+      const component = mount(
+        <Input
+          name="name"
+          label="Name"
+          onChange={onChange}
+          value="4151 1124"
+          type="password"
+          placeholder="Your name"
+          mask="1111 1111 1111 1111"
+          maskChar={null}
+          hint="Hi"
+          error="Error"
+        />
+      )
+
+      expect(component.props().mask).not.toBeUndefined()
+      expect(component.props().mask).toEqual('1111 1111 1111 1111')
+      expect(component.html()).toContain('4151 1124 ')
+    })
+
     it('should trigger onFocus', () => {
       const onChange = jest.fn()
       const onFocus = jest.fn()

--- a/src/Snackbar/Snackbar.test.js
+++ b/src/Snackbar/Snackbar.test.js
@@ -124,7 +124,7 @@ describe('snackbar', () => {
       () => {
         content = container.querySelector('p')
         expect(content).toBeNull()
-      }
+      }, 1000
     )
   })
 

--- a/stories/Input/default.js
+++ b/stories/Input/default.js
@@ -19,6 +19,7 @@ class InputState extends React.Component {
       icon,
       label,
       mask,
+      maskChar,
       multiline,
       placeholder,
       size,
@@ -37,6 +38,7 @@ class InputState extends React.Component {
         icon={icon}
         label={label}
         mask={mask}
+        maskChar={maskChar}
         multiline={multiline}
         name="email"
         onBlur={action('blur')}
@@ -110,6 +112,16 @@ storiesOf('Inputs', module)
       <Section title="Masked input">
         <InputState
           mask="111-111-111"
+          placeholder="Type your phone number"
+          type="tel"
+          value=""
+        />
+      </Section>
+
+      <Section title="Masked input without Masked Char">
+        <InputState
+          mask="111-111-111"
+          maskChar={null}
           placeholder="Type your phone number"
           type="tel"
           value=""
@@ -244,6 +256,17 @@ storiesOf('Inputs', module)
         <InputState
           base="dark"
           mask="111-111-111"
+          placeholder="Type your phone number"
+          type="phone"
+          value=""
+        />
+      </Section>
+
+      <Section title="Masked input without Masked Char" base="dark">
+        <InputState
+          base="dark"
+          mask="111-111-111"
+          maskChar={null}
           placeholder="Type your phone number"
           type="phone"
           value=""

--- a/stories/Input/form.js
+++ b/stories/Input/form.js
@@ -19,6 +19,7 @@ class InputState extends React.Component {
       icon,
       label,
       mask,
+      maskChar,
       multiline,
       placeholder,
       type,
@@ -36,6 +37,7 @@ class InputState extends React.Component {
         icon={icon}
         label={label}
         mask={mask}
+        maskChar={maskChar}
         multiline={multiline}
         name="email"
         onBlur={action('blur')}
@@ -100,6 +102,17 @@ storiesOf('Inputs', module)
         <InputState
           label="Phone number"
           mask="111-111-111"
+          placeholder="Type your phone number"
+          type="tel"
+          value="431-051-080"
+        />
+      </Section>
+
+      <Section title="Masked input without Masked Char">
+        <InputState
+          label="Phone number"
+          mask="111-111-111"
+          maskChar={null}
           placeholder="Type your phone number"
           type="tel"
           value="431-051-080"

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -17266,6 +17266,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17311,6 +17312,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17356,6 +17358,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17401,6 +17404,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17446,6 +17450,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -17491,6 +17496,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -17567,6 +17573,52 @@ exports[`Storyshots Inputs Default 1`] = `
       className=""
     >
       <h2>
+        Masked input without Masked Char
+      </h2>
+      <div>
+        <div
+          className="input light"
+        >
+          <div
+            className="boxContainer"
+          >
+            <div
+              className="container"
+            >
+              <input
+                disabled={false}
+                name="email"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyPress={null}
+                onMouseDown={[Function]}
+                onPaste={[Function]}
+                placeholder="Type your phone number"
+                size={null}
+                type="tel"
+                value=""
+              />
+              <label
+                className=""
+                htmlFor="email-shortid-mock"
+              >
+                Your email
+              </label>
+            </div>
+            <p
+              className="secondaryText"
+            >
+              Secondary text
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
         Multiline default
       </h2>
       <div>
@@ -17581,6 +17633,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17631,6 +17684,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17681,6 +17735,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -17736,6 +17791,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17789,6 +17845,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17842,6 +17899,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="name-shortid-mock"
+                maskChar="_"
                 name="name"
                 onBlur={[Function]}
                 onChange={null}
@@ -17890,6 +17948,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -17948,6 +18007,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18006,6 +18066,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -18053,6 +18114,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18106,6 +18168,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18159,6 +18222,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="pass-shortid-mock"
+                maskChar="_"
                 name="pass"
                 onBlur={[Function]}
                 onChange={null}
@@ -18204,6 +18268,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18249,6 +18314,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18294,6 +18360,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18339,6 +18406,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -18384,6 +18452,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -18460,6 +18529,52 @@ exports[`Storyshots Inputs Default 1`] = `
       className=""
     >
       <h2>
+        Masked input without Masked Char
+      </h2>
+      <div>
+        <div
+          className="input dark"
+        >
+          <div
+            className="boxContainer"
+          >
+            <div
+              className="container"
+            >
+              <input
+                disabled={false}
+                name="email"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyPress={null}
+                onMouseDown={[Function]}
+                onPaste={[Function]}
+                placeholder="Type your phone number"
+                size={null}
+                type="tel"
+                value=""
+              />
+              <label
+                className=""
+                htmlFor="email-shortid-mock"
+              >
+                Your email
+              </label>
+            </div>
+            <p
+              className="secondaryText"
+            >
+              Secondary text
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
         Multiline default
       </h2>
       <div>
@@ -18474,6 +18589,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18524,6 +18640,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18574,6 +18691,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -18629,6 +18747,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18682,6 +18801,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18735,6 +18855,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="name-shortid-mock"
+                maskChar="_"
                 name="name"
                 onBlur={[Function]}
                 onChange={null}
@@ -18783,6 +18904,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18841,6 +18963,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18899,6 +19022,7 @@ exports[`Storyshots Inputs Default 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -18946,6 +19070,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -18999,6 +19124,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19052,6 +19178,7 @@ exports[`Storyshots Inputs Default 1`] = `
               <input
                 disabled={true}
                 id="pass-shortid-mock"
+                maskChar="_"
                 name="pass"
                 onBlur={[Function]}
                 onChange={null}
@@ -19108,6 +19235,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19153,6 +19281,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19198,6 +19327,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -19243,6 +19373,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -19319,6 +19450,52 @@ exports[`Storyshots Inputs Form 1`] = `
       className=""
     >
       <h2>
+        Masked input without Masked Char
+      </h2>
+      <div>
+        <div
+          className="input light active"
+        >
+          <div
+            className="boxContainer"
+          >
+            <div
+              className="container"
+            >
+              <input
+                disabled={false}
+                name="email"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onKeyPress={null}
+                onMouseDown={[Function]}
+                onPaste={[Function]}
+                placeholder="Type your phone number"
+                size={null}
+                type="tel"
+                value="431-051-080"
+              />
+              <label
+                className="contentPresent"
+                htmlFor="email-shortid-mock"
+              >
+                Phone number
+              </label>
+            </div>
+            <p
+              className="secondaryText"
+            >
+              Secondary Text
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+    <section
+      className=""
+    >
+      <h2>
         Multiline default
       </h2>
       <div>
@@ -19333,6 +19510,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19383,6 +19561,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19433,6 +19612,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -19488,6 +19668,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19541,6 +19722,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19594,6 +19776,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="name-shortid-mock"
+                maskChar="_"
                 name="name"
                 onBlur={[Function]}
                 onChange={null}
@@ -19642,6 +19825,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19700,6 +19884,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19758,6 +19943,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -19805,6 +19991,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19858,6 +20045,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -19911,6 +20099,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="pass-shortid-mock"
+                maskChar="_"
                 name="pass"
                 onBlur={[Function]}
                 onChange={null}
@@ -19956,6 +20145,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="pass-shortid-mock"
+                maskChar="_"
                 name="pass"
                 onBlur={[Function]}
                 onChange={null}
@@ -20001,6 +20191,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20046,6 +20237,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20091,6 +20283,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -20136,6 +20329,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={null}
@@ -20226,6 +20420,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20276,6 +20471,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20326,6 +20522,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -20381,6 +20578,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20434,6 +20632,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20487,6 +20686,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="name-shortid-mock"
+                maskChar="_"
                 name="name"
                 onBlur={[Function]}
                 onChange={null}
@@ -20535,6 +20735,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20593,6 +20794,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={false}
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20651,6 +20853,7 @@ exports[`Storyshots Inputs Form 1`] = `
             >
               <textarea
                 disabled={true}
+                maskChar="_"
                 name="multiline"
                 onBlur={[Function]}
                 onChange={null}
@@ -20698,6 +20901,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20751,6 +20955,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={false}
                 id="email-shortid-mock"
+                maskChar="_"
                 name="email"
                 onBlur={[Function]}
                 onChange={[Function]}
@@ -20804,6 +21009,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="pass-shortid-mock"
+                maskChar="_"
                 name="pass"
                 onBlur={[Function]}
                 onChange={null}
@@ -20849,6 +21055,7 @@ exports[`Storyshots Inputs Form 1`] = `
               <input
                 disabled={true}
                 id="pass-shortid-mock"
+                maskChar="_"
                 name="pass"
                 onBlur={[Function]}
                 onChange={null}
@@ -20947,6 +21154,7 @@ exports[`Storyshots Landing Pagar.me login 1`] = `
                     <input
                       disabled={false}
                       id="email-shortid-mock"
+                      maskChar="_"
                       name="email"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -20978,6 +21186,7 @@ exports[`Storyshots Landing Pagar.me login 1`] = `
                     <input
                       disabled={false}
                       id="password-shortid-mock"
+                      maskChar="_"
                       name="password"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21107,6 +21316,7 @@ exports[`Storyshots Landing Pagar.me login light 1`] = `
                     <input
                       disabled={false}
                       id="email-shortid-mock"
+                      maskChar="_"
                       name="email"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21138,6 +21348,7 @@ exports[`Storyshots Landing Pagar.me login light 1`] = `
                     <input
                       disabled={false}
                       id="password-shortid-mock"
+                      maskChar="_"
                       name="password"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21269,6 +21480,7 @@ exports[`Storyshots Landing Pagar.me password recovery 1`] = `
                       <input
                         disabled={false}
                         id="email-shortid-mock"
+                        maskChar="_"
                         name="email"
                         onBlur={[Function]}
                         onChange={[Function]}
@@ -21502,6 +21714,7 @@ exports[`Storyshots Landing Pagar.me sign in 1`] = `
                     <input
                       disabled={false}
                       id="name-shortid-mock"
+                      maskChar="_"
                       name="name"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21533,6 +21746,7 @@ exports[`Storyshots Landing Pagar.me sign in 1`] = `
                     <input
                       disabled={false}
                       id="company-shortid-mock"
+                      maskChar="_"
                       name="company"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21564,6 +21778,7 @@ exports[`Storyshots Landing Pagar.me sign in 1`] = `
                     <input
                       disabled={false}
                       id="email-shortid-mock"
+                      maskChar="_"
                       name="email"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21595,6 +21810,7 @@ exports[`Storyshots Landing Pagar.me sign in 1`] = `
                     <input
                       disabled={false}
                       id="password-shortid-mock"
+                      maskChar="_"
                       name="password"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21814,6 +22030,7 @@ exports[`Storyshots Landing Pagar.me two factor login 1`] = `
                     <input
                       disabled={false}
                       id="email-shortid-mock"
+                      maskChar="_"
                       name="email"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21845,6 +22062,7 @@ exports[`Storyshots Landing Pagar.me two factor login 1`] = `
                     <input
                       disabled={false}
                       id="password-shortid-mock"
+                      maskChar="_"
                       name="password"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -21876,6 +22094,7 @@ exports[`Storyshots Landing Pagar.me two factor login 1`] = `
                     <input
                       disabled={false}
                       id="token-shortid-mock"
+                      maskChar="_"
                       name="token"
                       onBlur={[Function]}
                       onChange={[Function]}
@@ -39079,6 +39298,7 @@ exports[`Storyshots Transition Picker 1`] = `
                   <input
                     disabled={false}
                     id="damping"
+                    maskChar="_"
                     max={115}
                     maxLength={3}
                     name=""
@@ -39121,6 +39341,7 @@ exports[`Storyshots Transition Picker 1`] = `
                   <input
                     disabled={false}
                     id="precision"
+                    maskChar="_"
                     maxLength={10}
                     name=""
                     onBlur={[Function]}
@@ -39162,6 +39383,7 @@ exports[`Storyshots Transition Picker 1`] = `
                   <input
                     disabled={false}
                     id="stiffness"
+                    maskChar="_"
                     max={500}
                     maxLength={3}
                     name=""


### PR DESCRIPTION
## Contexto
Atualmente a máscara utilizada no componente `<Input />` possuí uma opção interna de desativar o carácter de preenchimento de máscara, porém não está sendo exportado em um Prop. 
Esse PR adiciona essa prop no componente

### Com carácter de máscara (default)
![image](https://user-images.githubusercontent.com/11414390/143673622-93ec694e-d840-450d-9f8f-8e43c5e69449.png)

### Sem carácter de máscara (maskChar={null})
![image](https://user-images.githubusercontent.com/11414390/143673636-b18d27f2-005d-4328-bf69-79da759b2d37.png)


## Checklist
- [x] Adiciona prop no componente e stories
- [x] Adiciona teste


## Como testar
- Rode o storybook e verifique o storie `Masked input without Masked Char` está executando um Input sem máscara