### PR TITLE
QA 1705 - refactor: update image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ image: ubuntu:16.04
 jobs:
   build:
     docker:
-      - image: circleci/node:12-browsers
+      - image: cimg/node:12.22.10-browsers
 
     working_directory: ~/repo
 


### PR DESCRIPTION
<!-- IMPORTANT: Please review the CONTRIBUTING.md file for detailed contributing guidelines and remove the items which you're not using. -->

## Context
The circleCI team notified us:

`I wanted to reach out because I noticed that there are still legacy convenience images being used in your account. These images are being deprecated in two rounds with the first round starting on Dec 31st. They will not be deleted, but they will no longer be supported. Below is a list of the projects currently using those images.`

This PR updates the Node image.

