### PR TITLE
[EXPRECEBE-492] Alterar espaçamento do ícone do menu no former-kit-skin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "former-kit",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "repository": {

--- a/src/Sidebar/SidebarLink.js
+++ b/src/Sidebar/SidebarLink.js
@@ -55,29 +55,40 @@ class SidebarLink extends React.Component {
       children,
       collapsed,
       'data-testid': dataTestId,
+      hasSeparator,
       icon,
+      iconRight,
       icons,
       theme,
       title,
     } = this.props
+
     return (
       <button
         data-testid={dataTestId}
         onBlur={this.handleBlur}
         onClick={this.handleClick}
         onFocus={this.handleFocus}
+        className={hasSeparator ? theme.separator : ''}
         role="link"
         type="button"
       >
         <div className={theme.title}>
-          <span className={theme.icon}>{icon}</span>
-          {title}
+          <div>
+            <span className={theme.icon}>{icon}</span>
+            {title}
+          </div>
           {children && (
             <span className={theme.arrow}>
               <Arrow
                 active={collapsed}
                 icons={icons}
               />
+            </span>
+          )}
+          {!children && !!iconRight && (
+            <span className={theme.arrow}>
+              {iconRight}
             </span>
           )}
         </div>
@@ -162,10 +173,18 @@ SidebarLink.propTypes = {
    */
   'data-testid': PropTypes.string,
   /**
+   * If true, includes a border at the top of the link
+   */
+  hasSeparator: PropTypes.bool,
+  /**
    * The icon defined by the user. It's shown with the title
    * and is also shown alone when the sidebar is collapsed.
    */
   icon: PropTypes.element,
+  /**
+   * The icon defined by the user. It's shown with the title
+   */
+  iconRight: PropTypes.element,
   /**
    * The icon theme for this element.
    * The icons 'collapse' and 'expand' are mandatory if
@@ -220,6 +239,10 @@ SidebarLink.propTypes = {
      */
     open: PropTypes.string,
     /**
+     * The class used to style the link that are a separator.
+     */
+    separator: PropTypes.string,
+    /**
      * The class used to submenu.
      */
     submenu: PropTypes.string,
@@ -239,7 +262,9 @@ SidebarLink.defaultProps = {
   children: null,
   collapsed: false,
   'data-testid': null,
+  hasSeparator: false,
   icon: null,
+  iconRight: null,
   icons: {},
   onBlur: null,
   onClick: null,

--- a/stories/Sidebar/SidebarState.js
+++ b/stories/Sidebar/SidebarState.js
@@ -2,6 +2,7 @@ import React from 'react'
 
 import shortid from 'shortid'
 import { contains } from 'ramda'
+import IconHelp from 'emblematic-icons/svg/Help24.svg'
 
 import {
   Sidebar,
@@ -59,6 +60,13 @@ const items = [
     title: 'Config',
     value: 'config',
   },
+  {
+    hasSeparator: true,
+    iconRight: <IconHelp width="18" height="18" />,
+    path: ['helpCenter'],
+    title: 'Help Center',
+    value: 'helpCenter',
+  },
 ]
 
 class SidebarState extends React.Component {
@@ -108,9 +116,11 @@ class SidebarState extends React.Component {
             {itemData.map(item => (
               <SidebarLink
                 key={item.value}
+                hasSeparator={item.hasSeparator}
                 title={item.title.toUpperCase()}
                 active={contains(item.value, active)}
                 onClick={() => this.handleClick(item)}
+                iconRight={item.iconRight}
                 collapsed={item.collapsed}
               >
                 {item.sublinks

--- a/stories/__snapshots__/storyshots.test.js.snap
+++ b/stories/__snapshots__/storyshots.test.js.snap
@@ -23481,6 +23481,7 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -23491,10 +23492,12 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      HOME
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HOME
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -23502,6 +23505,7 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -23512,10 +23516,12 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      TRANSACTIONS
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        TRANSACTIONS
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -23523,6 +23529,7 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -23533,10 +23540,12 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      MY ACCOUNT
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        MY ACCOUNT
+                      </div>
                       <span
                         className="arrow"
                       >
@@ -23549,6 +23558,7 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -23559,14 +23569,48 @@ exports[`Storyshots Layout Default only Sidebar 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      CONFIG
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        CONFIG
+                      </div>
                       <span
                         className="arrow"
                       >
                         <svg />
+                      </span>
+                    </div>
+                  </button>
+                </li>
+                <li
+                  className="link"
+                >
+                  <button
+                    className="separator"
+                    data-testid={null}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="link"
+                    type="button"
+                  >
+                    <div
+                      className="title"
+                    >
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HELP CENTER
+                      </div>
+                      <span
+                        className="arrow"
+                      >
+                        <Help24.svg
+                          height="18"
+                          width="18"
+                        />
                       </span>
                     </div>
                   </button>
@@ -23997,6 +24041,7 @@ exports[`Storyshots Layout Default with all props 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24007,10 +24052,12 @@ exports[`Storyshots Layout Default with all props 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      HOME
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HOME
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -24018,6 +24065,7 @@ exports[`Storyshots Layout Default with all props 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24028,10 +24076,12 @@ exports[`Storyshots Layout Default with all props 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      TRANSACTIONS
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        TRANSACTIONS
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -24039,6 +24089,7 @@ exports[`Storyshots Layout Default with all props 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24049,10 +24100,12 @@ exports[`Storyshots Layout Default with all props 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      MY ACCOUNT
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        MY ACCOUNT
+                      </div>
                       <span
                         className="arrow"
                       >
@@ -24065,6 +24118,7 @@ exports[`Storyshots Layout Default with all props 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24075,14 +24129,48 @@ exports[`Storyshots Layout Default with all props 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      CONFIG
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        CONFIG
+                      </div>
                       <span
                         className="arrow"
                       >
                         <svg />
+                      </span>
+                    </div>
+                  </button>
+                </li>
+                <li
+                  className="link"
+                >
+                  <button
+                    className="separator"
+                    data-testid={null}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="link"
+                    type="button"
+                  >
+                    <div
+                      className="title"
+                    >
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HELP CENTER
+                      </div>
+                      <span
+                        className="arrow"
+                      >
+                        <Help24.svg
+                          height="18"
+                          width="18"
+                        />
                       </span>
                     </div>
                   </button>
@@ -24627,6 +24715,7 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24637,10 +24726,12 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      HOME
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HOME
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -24648,6 +24739,7 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24658,10 +24750,12 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      TRANSACTIONS
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        TRANSACTIONS
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -24669,6 +24763,7 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24679,10 +24774,12 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      MY ACCOUNT
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        MY ACCOUNT
+                      </div>
                       <span
                         className="arrow"
                       >
@@ -24695,6 +24792,7 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -24705,14 +24803,48 @@ exports[`Storyshots Layout Default without Footer 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      CONFIG
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        CONFIG
+                      </div>
                       <span
                         className="arrow"
                       >
                         <svg />
+                      </span>
+                    </div>
+                  </button>
+                </li>
+                <li
+                  className="link"
+                >
+                  <button
+                    className="separator"
+                    data-testid={null}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="link"
+                    type="button"
+                  >
+                    <div
+                      className="title"
+                    >
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HELP CENTER
+                      </div>
+                      <span
+                        className="arrow"
+                      >
+                        <Help24.svg
+                          height="18"
+                          width="18"
+                        />
                       </span>
                     </div>
                   </button>
@@ -25195,6 +25327,7 @@ exports[`Storyshots Layout Default without Header 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -25205,10 +25338,12 @@ exports[`Storyshots Layout Default without Header 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      HOME
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HOME
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -25216,6 +25351,7 @@ exports[`Storyshots Layout Default without Header 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -25226,10 +25362,12 @@ exports[`Storyshots Layout Default without Header 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      TRANSACTIONS
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        TRANSACTIONS
+                      </div>
                     </div>
                   </button>
                 </li>
@@ -25237,6 +25375,7 @@ exports[`Storyshots Layout Default without Header 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -25247,10 +25386,12 @@ exports[`Storyshots Layout Default without Header 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      MY ACCOUNT
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        MY ACCOUNT
+                      </div>
                       <span
                         className="arrow"
                       >
@@ -25263,6 +25404,7 @@ exports[`Storyshots Layout Default without Header 1`] = `
                   className="link"
                 >
                   <button
+                    className=""
                     data-testid={null}
                     onBlur={[Function]}
                     onClick={[Function]}
@@ -25273,14 +25415,48 @@ exports[`Storyshots Layout Default without Header 1`] = `
                     <div
                       className="title"
                     >
-                      <span
-                        className="icon"
-                      />
-                      CONFIG
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        CONFIG
+                      </div>
                       <span
                         className="arrow"
                       >
                         <svg />
+                      </span>
+                    </div>
+                  </button>
+                </li>
+                <li
+                  className="link"
+                >
+                  <button
+                    className="separator"
+                    data-testid={null}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onFocus={[Function]}
+                    role="link"
+                    type="button"
+                  >
+                    <div
+                      className="title"
+                    >
+                      <div>
+                        <span
+                          className="icon"
+                        />
+                        HELP CENTER
+                      </div>
+                      <span
+                        className="arrow"
+                      >
+                        <Help24.svg
+                          height="18"
+                          width="18"
+                        />
                       </span>
                     </div>
                   </button>
@@ -32004,6 +32180,7 @@ exports[`Storyshots Sidebar Default 1`] = `
               className="link"
             >
               <button
+                className=""
                 data-testid={null}
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -32014,10 +32191,12 @@ exports[`Storyshots Sidebar Default 1`] = `
                 <div
                   className="title"
                 >
-                  <span
-                    className="icon"
-                  />
-                  HOME
+                  <div>
+                    <span
+                      className="icon"
+                    />
+                    HOME
+                  </div>
                 </div>
               </button>
             </li>
@@ -32025,6 +32204,7 @@ exports[`Storyshots Sidebar Default 1`] = `
               className="link"
             >
               <button
+                className=""
                 data-testid={null}
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -32035,10 +32215,12 @@ exports[`Storyshots Sidebar Default 1`] = `
                 <div
                   className="title"
                 >
-                  <span
-                    className="icon"
-                  />
-                  TRANSACTIONS
+                  <div>
+                    <span
+                      className="icon"
+                    />
+                    TRANSACTIONS
+                  </div>
                 </div>
               </button>
             </li>
@@ -32046,6 +32228,7 @@ exports[`Storyshots Sidebar Default 1`] = `
               className="link"
             >
               <button
+                className=""
                 data-testid={null}
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -32056,10 +32239,12 @@ exports[`Storyshots Sidebar Default 1`] = `
                 <div
                   className="title"
                 >
-                  <span
-                    className="icon"
-                  />
-                  MY ACCOUNT
+                  <div>
+                    <span
+                      className="icon"
+                    />
+                    MY ACCOUNT
+                  </div>
                   <span
                     className="arrow"
                   >
@@ -32072,6 +32257,7 @@ exports[`Storyshots Sidebar Default 1`] = `
               className="link"
             >
               <button
+                className=""
                 data-testid={null}
                 onBlur={[Function]}
                 onClick={[Function]}
@@ -32082,14 +32268,48 @@ exports[`Storyshots Sidebar Default 1`] = `
                 <div
                   className="title"
                 >
-                  <span
-                    className="icon"
-                  />
-                  CONFIG
+                  <div>
+                    <span
+                      className="icon"
+                    />
+                    CONFIG
+                  </div>
                   <span
                     className="arrow"
                   >
                     <svg />
+                  </span>
+                </div>
+              </button>
+            </li>
+            <li
+              className="link"
+            >
+              <button
+                className="separator"
+                data-testid={null}
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                role="link"
+                type="button"
+              >
+                <div
+                  className="title"
+                >
+                  <div>
+                    <span
+                      className="icon"
+                    />
+                    HELP CENTER
+                  </div>
+                  <span
+                    className="arrow"
+                  >
+                    <Help24.svg
+                      height="18"
+                      width="18"
+                    />
                   </span>
                 </div>
               </button>


### PR DESCRIPTION
## Context
Esse PR implementa uma alteração no SidebarLink, adicionando uma div para separar o icone da esquerda e o texto do link, da seta da direita. Para que com um `justify-content: space-between` o link mantenha a seta separada no seu canto direito. Além disso, inclui duas novas propriedades no `SidebarLink`, sendo elas: `hasSeparator` que indicará se o item deverá possuir uma separação dos itens acima, e `iconRight`,  que irá adicionar um icone a direita do menu. 

## Checklist
- [x] Separar texto e icone da esquerda do icone de seta da direita
- [x] Adicionar opção para separar itens do menu
- [x] Adicionar opção para adicionar um icone a direita do menu

## Linked Issues
- [EXPRECEBE-492] 

## Screenshots
<img width="266" alt="Captura de Tela 2023-11-24 às 15 02 22" src="https://github.com/pagarme/former-kit/assets/28263075/9d2c8882-32ab-4782-991f-a90ff8417a26">

### Layout:
![image](https://github.com/pagarme/former-kit/assets/28263075/e40c157b-bfa5-4cdc-8824-a3745e6ca19c)

[EXPRECEBE-492]: https://mundipagg.atlassian.net/browse/EXPRECEBE-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ